### PR TITLE
Remove reference to ArcGISExceptionDomain

### DIFF
--- a/lib/src/samples/authenticate_with_oauth_sample.dart
+++ b/lib/src/samples/authenticate_with_oauth_sample.dart
@@ -103,8 +103,7 @@ class _AuthenticateWithOAuthSampleState
     } on ArcGISException catch (error) {
       // Sign in was canceled, or there was some other error.
       final e = (error.wrappedException as ArcGISException?) ?? error;
-      if (e.domain == ArcGISExceptionDomain.arcGISRuntime &&
-          e.errorType == ArcGISExceptionType.commonUserCanceled) {
+      if (e.errorType == ArcGISExceptionType.commonUserCanceled) {
         challenge.cancel();
       } else {
         challenge.continueAndFail();


### PR DESCRIPTION
ArcGISExceptionDomain will no longer be part of the public interface.