### PR TITLE
Updated ServiceFeatureTable URI constructor calls

### DIFF
--- a/lib/src/samples/add_feature_layers_sample.dart
+++ b/lib/src/samples/add_feature_layers_sample.dart
@@ -103,7 +103,7 @@ class AddFeatureLayersSampleState extends State<AddFeatureLayersSample> {
   void loadFeatureServiceFromUri() {
     final uri = Uri.parse(
         'https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0');
-    final serviceFeatureTable = ServiceFeatureTable.fromUri(uri);
+    final serviceFeatureTable = ServiceFeatureTable.withUri(uri);
     final featureLayer = FeatureLayer.withFeatureTable(serviceFeatureTable);
     _map.operationalLayers.clear();
     _map.operationalLayers.add(featureLayer);

--- a/lib/src/samples/apply_simple_renderer_to_feature_layer_sample.dart
+++ b/lib/src/samples/apply_simple_renderer_to_feature_layer_sample.dart
@@ -41,7 +41,7 @@ class ApplySimpleRendererToFeatureLayerSampleState
 
     final uri = Uri.parse(
         'https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0');
-    final serviceFeatureTable = ServiceFeatureTable.fromUri(uri);
+    final serviceFeatureTable = ServiceFeatureTable.withUri(uri);
     _featureLayer = FeatureLayer.withFeatureTable(serviceFeatureTable);
     _map.operationalLayers.add(_featureLayer);
     _map.initialViewpoint = Viewpoint.fromCenter(

--- a/lib/src/samples/apply_unique_value_renderer_sample.dart
+++ b/lib/src/samples/apply_unique_value_renderer_sample.dart
@@ -45,7 +45,7 @@ class ApplyUniqueValueRendererSampleState
 
     final uri = Uri.parse(
         'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3');
-    final serviceFeatureTable = ServiceFeatureTable.fromUri(uri);
+    final serviceFeatureTable = ServiceFeatureTable.withUri(uri);
     final featureLayer = FeatureLayer.withFeatureTable(serviceFeatureTable);
     featureLayer.renderer = _configureUniqueValueRenderer();
 

--- a/lib/src/samples/filter_by_definition_expression_or_display_filter_sample.dart
+++ b/lib/src/samples/filter_by_definition_expression_or_display_filter_sample.dart
@@ -33,7 +33,7 @@ class FilterByDefinitionExpressionOrDisplayFilterSampleState
     extends State<FilterByDefinitionExpressionOrDisplayFilterSample> {
   final _mapViewController = ArcGISMapView.createController();
   final _featureLayer = FeatureLayer.withFeatureTable(
-      ServiceFeatureTable.fromUri(Uri.parse(
+      ServiceFeatureTable.withUri(Uri.parse(
           'https://services2.arcgis.com/ZQgQTuoyBrtmoGdP/arcgis/rest/services/SF_311_Incidents/FeatureServer/0')));
 
   @override

--- a/lib/src/samples/find_closest_facility_sample.dart
+++ b/lib/src/samples/find_closest_facility_sample.dart
@@ -125,7 +125,7 @@ class FindClosestFacilitySampleState extends State<FindClosestFacilitySample> {
   }
 
   FeatureLayer buildFeatureLayer(Uri tableUri, Uri imageUri) {
-    final featureTable = ServiceFeatureTable.fromUri(tableUri);
+    final featureTable = ServiceFeatureTable.withUri(tableUri);
     final featureLayer = FeatureLayer.withFeatureTable(featureTable);
     final markerSymbol = PictureMarkerSymbol.withUrl(imageUri);
     markerSymbol.width = 30;

--- a/lib/src/samples/identify_layers_sample.dart
+++ b/lib/src/samples/identify_layers_sample.dart
@@ -46,7 +46,7 @@ class IdentifyLayersSampleState extends State<IdentifyLayersSample> {
       scale: 68015210,
     );
 
-    final serviceFeatureTable = ServiceFeatureTable.fromUri(Uri.parse(
+    final serviceFeatureTable = ServiceFeatureTable.withUri(Uri.parse(
         'https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0'));
     final featureLayer = FeatureLayer.withFeatureTable(serviceFeatureTable);
 

--- a/lib/src/samples/query_feature_table_sample.dart
+++ b/lib/src/samples/query_feature_table_sample.dart
@@ -85,7 +85,7 @@ class QueryFeatureTableSampleState extends State<QueryFeatureTableSample> {
   void onMapViewReady() async {
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
 
-    _featureTable = ServiceFeatureTable.fromUri(Uri.parse(
+    _featureTable = ServiceFeatureTable.withUri(Uri.parse(
         'https://services.arcgis.com/jIL9msH9OI208GCb/arcgis/rest/services/USA_Daytime_Population_2016/FeatureServer/0'));
     await _featureTable.load();
     _featureLayer = FeatureLayer.withFeatureTable(_featureTable);

--- a/lib/src/samples/query_table_statistics_sample.dart
+++ b/lib/src/samples/query_table_statistics_sample.dart
@@ -32,7 +32,7 @@ class QueryTableStatisticsSample extends StatefulWidget {
 class QueryTableStatisticsSampleState
     extends State<QueryTableStatisticsSample> {
   final _mapViewController = ArcGISMapView.createController();
-  final _serviceFeatureTable = ServiceFeatureTable.fromUri(Uri.parse(
+  final _serviceFeatureTable = ServiceFeatureTable.withUri(Uri.parse(
       'https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer/0'));
   bool _onlyCitiesInCurrentExtent = true;
   bool _onlyCitiesGreaterThan5M = true;

--- a/lib/src/samples/select_features_in_feature_layer_sample.dart
+++ b/lib/src/samples/select_features_in_feature_layer_sample.dart
@@ -33,7 +33,7 @@ class SelectFeaturesInFeatureLayerSampleState
     extends State<SelectFeaturesInFeatureLayerSample> {
   final _mapViewController = ArcGISMapView.createController();
   final _featureLayer = FeatureLayer.withFeatureTable(
-      ServiceFeatureTable.fromUri(Uri.parse(
+      ServiceFeatureTable.withUri(Uri.parse(
           'https://services1.arcgis.com/4yjifSiIG17X0gW4/arcgis/rest/services/GDP_per_capita_1960_2016/FeatureServer/0')));
 
   @override


### PR DESCRIPTION
The factory constructor `fromUri(Uri)` has been changed to `withUri(Uri)`. This PR updates the uses of the constructor in the samples.