### PR TITLE
Remove extraneous symlinks

### DIFF
--- a/android/app/src/main/jniLibs/assets/libarcgis_maps_ffi.so
+++ b/android/app/src/main/jniLibs/assets/libarcgis_maps_ffi.so
@@ -1,1 +1,0 @@
-../../../../../../arcgis_maps_core/android/assets/libarcgis_maps_ffi.so

--- a/android/app/src/main/jniLibs/assets/libruntimecore.so
+++ b/android/app/src/main/jniLibs/assets/libruntimecore.so
@@ -1,1 +1,0 @@
-../../../../../../arcgis_maps_core/android/assets/libruntimecore.so


### PR DESCRIPTION
These symlinks were erroneously added by `dart run arcgis_maps install`. It incorrectly treated the "assets" folder as one of the hardware architectures. That's been fixed elsewhere, but here we need to remove the bad symlinks that made it into the repo.