### PR TITLE
Upgrade to Flutter 3.22, which comes with Dart 3.4.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.3 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Upgrade to Flutter 3.22. The only difference was to move the Dart version to 3.4.3 (no deprecations, warnings, etc).