### PR TITLE
Provide a mixin to resolve "setState called after dispose" exceptions

### DIFF
--- a/lib/samples/add_feature_collection_layer_from_table/add_feature_collection_layer_from_table_sample.dart
+++ b/lib/samples/add_feature_collection_layer_from_table/add_feature_collection_layer_from_table_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class AddFeatureCollectionLayerFromTableSample extends StatefulWidget {
   const AddFeatureCollectionLayerFromTableSample({super.key});
   @override
@@ -25,7 +27,8 @@ class AddFeatureCollectionLayerFromTableSample extends StatefulWidget {
 }
 
 class _AddFeatureCollectionLayerFromTableSampleState
-    extends State<AddFeatureCollectionLayerFromTableSample> {
+    extends State<AddFeatureCollectionLayerFromTableSample>
+    with SampleStateSupport {
   final _featureCollection = FeatureCollection();
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/add_feature_layers/add_feature_layers_sample.dart
+++ b/lib/samples/add_feature_layers/add_feature_layers_sample.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../utils/sample_data.dart';
+import '../../utils/sample_state_support.dart';
 
 // create an enumeration to define the feature layer sources.
 enum Source { url, portalItem, geodatabase, geopackage }
@@ -32,7 +33,8 @@ class AddFeatureLayersSample extends StatefulWidget {
   State<AddFeatureLayersSample> createState() => _AddFeatureLayersSampleState();
 }
 
-class _AddFeatureLayersSampleState extends State<AddFeatureLayersSample> {
+class _AddFeatureLayersSampleState extends State<AddFeatureLayersSample>
+    with SampleStateSupport {
   // create a map with a topographic basemap style.
   final _map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
   // create a map view controller.

--- a/lib/samples/add_tiled_layer/add_tiled_layer_sample.dart
+++ b/lib/samples/add_tiled_layer/add_tiled_layer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class AddTiledLayerSample extends StatefulWidget {
   const AddTiledLayerSample({super.key});
 
@@ -24,7 +26,8 @@ class AddTiledLayerSample extends StatefulWidget {
   State<AddTiledLayerSample> createState() => _AddTiledLayerSampleState();
 }
 
-class _AddTiledLayerSampleState extends State<AddTiledLayerSample> {
+class _AddTiledLayerSampleState extends State<AddTiledLayerSample>
+    with SampleStateSupport {
   // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
+++ b/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
@@ -19,6 +19,8 @@ import 'package:arcgis_maps_sdk_flutter_samples/utils/sample_data.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class AddTiledLayerAsBasemapSample extends StatefulWidget {
   const AddTiledLayerAsBasemapSample({super.key});
 
@@ -28,14 +30,12 @@ class AddTiledLayerAsBasemapSample extends StatefulWidget {
 }
 
 class AddTiledLayerAsBasemapSampleState
-    extends State<AddTiledLayerAsBasemapSample> {
-  // create a controller for the map view.
+    extends State<AddTiledLayerAsBasemapSample> with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // add a map view to the widget tree and set a controller.
       body: ArcGISMapView(
         controllerProvider: () => _mapViewController,
         onMapViewReady: onMapViewReady,
@@ -45,20 +45,14 @@ class AddTiledLayerAsBasemapSampleState
 
   void onMapViewReady() async {
     await downloadSampleData(['e4a398afe9a945f3b0f4dca1e4faccb5']);
-    final appDir = await getApplicationDocumentsDirectory();
-
-    // create a tile cache, specifying the path to the local tile package.
     const tilePackageName = 'SanFrancisco.tpkx';
+    final appDir = await getApplicationDocumentsDirectory();
     final pathToFile = '${appDir.absolute.path}/$tilePackageName';
-    final tileCache = TileCache.withFileUri(Uri.parse(pathToFile));
 
-    // create a tiled layer with the tile cache.
+    final tileCache = TileCache.withFileUri(Uri.parse(pathToFile));
     final tiledLayer = ArcGISTiledLayer.withTileCache(tileCache);
-    // create a basemap with the tiled layer.
     final basemap = Basemap.withBaseLayer(tiledLayer);
-    // create a map with the basemap.
     final map = ArcGISMap.withBasemap(basemap);
-    // set the map to the map view.
     _mapViewController.arcGISMap = map;
   }
 }

--- a/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
+++ b/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
@@ -31,11 +31,13 @@ class AddTiledLayerAsBasemapSample extends StatefulWidget {
 
 class AddTiledLayerAsBasemapSampleState
     extends State<AddTiledLayerAsBasemapSample> with SampleStateSupport {
+  // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      // add a map view to the widget tree and set a controller.
       body: ArcGISMapView(
         controllerProvider: () => _mapViewController,
         onMapViewReady: onMapViewReady,
@@ -45,14 +47,20 @@ class AddTiledLayerAsBasemapSampleState
 
   void onMapViewReady() async {
     await downloadSampleData(['e4a398afe9a945f3b0f4dca1e4faccb5']);
-    const tilePackageName = 'SanFrancisco.tpkx';
     final appDir = await getApplicationDocumentsDirectory();
-    final pathToFile = '${appDir.absolute.path}/$tilePackageName';
 
+    // create a tile cache, specifying the path to the local tile package.
+    const tilePackageName = 'SanFrancisco.tpkx';
+    final pathToFile = '${appDir.absolute.path}/$tilePackageName';
     final tileCache = TileCache.withFileUri(Uri.parse(pathToFile));
+
+    // create a tiled layer with the tile cache.
     final tiledLayer = ArcGISTiledLayer.withTileCache(tileCache);
+    // create a basemap with the tiled layer.
     final basemap = Basemap.withBaseLayer(tiledLayer);
+    // create a map with the basemap.
     final map = ArcGISMap.withBasemap(basemap);
+    // set the map to the map view.
     _mapViewController.arcGISMap = map;
   }
 }

--- a/lib/samples/add_vector_tiled_layer/add_vector_tiled_layer_sample.dart
+++ b/lib/samples/add_vector_tiled_layer/add_vector_tiled_layer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 // An enumeration of vector tiled layers to choose from.
 enum VectorTiledItem {
   midCentury('Mid-Century', '7675d44bb1e4428aa2c30a9b68f97822'),
@@ -46,7 +48,8 @@ class AddVectorTiledLayerSample extends StatefulWidget {
       _AddVectorTiledLayerSampleState();
 }
 
-class _AddVectorTiledLayerSampleState extends State<AddVectorTiledLayerSample> {
+class _AddVectorTiledLayerSampleState extends State<AddVectorTiledLayerSample>
+    with SampleStateSupport {
   // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
   // prepare menu items for the selection of vector tiled layers.

--- a/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
+++ b/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ApplyClassBreaksRendererToSublayerSample extends StatefulWidget {
   const ApplyClassBreaksRendererToSublayerSample({super.key});
 
@@ -26,7 +28,8 @@ class ApplyClassBreaksRendererToSublayerSample extends StatefulWidget {
 }
 
 class _ApplyClassBreaksRendererToSublayerSampleState
-    extends State<ApplyClassBreaksRendererToSublayerSample> {
+    extends State<ApplyClassBreaksRendererToSublayerSample>
+    with SampleStateSupport {
   // create a map view controller
   final _mapViewController = ArcGISMapView.createController();
   // create a map with a basemap style

--- a/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area_sample.dart
+++ b/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area_sample.dart
@@ -147,14 +147,12 @@ class _ApplyScheduledUpdatesToPreplannedMapAreaSampleState
   // Function to check for map package updates
   Future<void> _checkForUpdates() async {
     final updatesInfo = await _offlineMapSyncTask!.checkForUpdates();
-    if (mounted) {
-      setState(() {
-        _updateStatus = updatesInfo.downloadAvailability;
-        _updateSizeKB = updatesInfo.scheduledUpdatesDownloadSize / 1024;
-        _canUpdate = updatesInfo.downloadAvailability ==
-            OfflineUpdateAvailability.available;
-      });
-    }
+    setState(() {
+      _updateStatus = updatesInfo.downloadAvailability;
+      _updateSizeKB = updatesInfo.scheduledUpdatesDownloadSize / 1024;
+      _canUpdate = updatesInfo.downloadAvailability ==
+          OfflineUpdateAvailability.available;
+    });
   }
 
   // Function to load the map package into the map

--- a/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area_sample.dart
+++ b/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area_sample.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../utils/sample_data.dart';
+import '../../utils/sample_state_support.dart';
 
 class ApplyScheduledUpdatesToPreplannedMapAreaSample extends StatefulWidget {
   const ApplyScheduledUpdatesToPreplannedMapAreaSample({super.key});
@@ -30,7 +31,8 @@ class ApplyScheduledUpdatesToPreplannedMapAreaSample extends StatefulWidget {
 }
 
 class _ApplyScheduledUpdatesToPreplannedMapAreaSampleState
-    extends State<ApplyScheduledUpdatesToPreplannedMapAreaSample> {
+    extends State<ApplyScheduledUpdatesToPreplannedMapAreaSample>
+    with SampleStateSupport {
   // Create the map controller
   final _mapViewController = ArcGISMapView.createController();
   // Flag indicating if an update is avalable for the map package

--- a/lib/samples/apply_simple_renderer_to_feature_layer/apply_simple_renderer_to_feature_layer_sample.dart
+++ b/lib/samples/apply_simple_renderer_to_feature_layer/apply_simple_renderer_to_feature_layer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ApplySimpleRendererToFeatureLayerSample extends StatefulWidget {
   const ApplySimpleRendererToFeatureLayerSample({super.key});
 
@@ -26,7 +28,8 @@ class ApplySimpleRendererToFeatureLayerSample extends StatefulWidget {
 }
 
 class _ApplySimpleRendererToFeatureLayerSampleState
-    extends State<ApplySimpleRendererToFeatureLayerSample> {
+    extends State<ApplySimpleRendererToFeatureLayerSample>
+    with SampleStateSupport {
   // The feature layer that will host the symbolized features
   late final FeatureLayer _featureLayer;
   // Create the map view controller

--- a/lib/samples/apply_unique_value_renderer/apply_unique_value_renderer_sample.dart
+++ b/lib/samples/apply_unique_value_renderer/apply_unique_value_renderer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ApplyUniqueValueRendererSample extends StatefulWidget {
   const ApplyUniqueValueRendererSample({super.key});
 
@@ -26,7 +28,7 @@ class ApplyUniqueValueRendererSample extends StatefulWidget {
 }
 
 class _ApplyUniqueValueRendererSampleState
-    extends State<ApplyUniqueValueRendererSample> {
+    extends State<ApplyUniqueValueRendererSample> with SampleStateSupport {
   // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/authenticate_with_oauth/authenticate_with_oauth_sample.dart
+++ b/lib/samples/authenticate_with_oauth/authenticate_with_oauth_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class AuthenticateWithOAuthSample extends StatefulWidget {
   const AuthenticateWithOAuthSample({super.key});
 
@@ -27,6 +29,7 @@ class AuthenticateWithOAuthSample extends StatefulWidget {
 
 class _AuthenticateWithOAuthSampleState
     extends State<AuthenticateWithOAuthSample>
+    with SampleStateSupport
     implements ArcGISAuthenticationChallengeHandler {
   // This document describes the steps to configure OAuth for your app:
   // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/user-authentication/serverless-native-flow/

--- a/lib/samples/display_clusters/display_clusters_sample.dart
+++ b/lib/samples/display_clusters/display_clusters_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class DisplayClustersSample extends StatefulWidget {
   const DisplayClustersSample({super.key});
 
@@ -24,7 +26,8 @@ class DisplayClustersSample extends StatefulWidget {
   State<DisplayClustersSample> createState() => _DisplayClustersSampleState();
 }
 
-class _DisplayClustersSampleState extends State<DisplayClustersSample> {
+class _DisplayClustersSampleState extends State<DisplayClustersSample>
+    with SampleStateSupport {
   // create a map view controller
   final _mapViewController = ArcGISMapView.createController();
   late ArcGISMap _map;

--- a/lib/samples/display_map_from_mobile_map_package/display_map_from_mobile_map_package_sample.dart
+++ b/lib/samples/display_map_from_mobile_map_package/display_map_from_mobile_map_package_sample.dart
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../utils/sample_data.dart';
+import '../../utils/sample_state_support.dart';
 
 class DisplayMapFromMobileMapPackageSample extends StatefulWidget {
   const DisplayMapFromMobileMapPackageSample({super.key});
@@ -31,7 +32,8 @@ class DisplayMapFromMobileMapPackageSample extends StatefulWidget {
 }
 
 class _DisplayMapFromMobileMapPackageSampleState
-    extends State<DisplayMapFromMobileMapPackageSample> {
+    extends State<DisplayMapFromMobileMapPackageSample>
+    with SampleStateSupport {
   // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
+++ b/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
@@ -92,13 +92,9 @@ class _DownloadPreplannedMapAreaSampleState
                 final map = await _downloadOfflineMap(index);
                 _mapViewController.arcGISMap = map;
               } catch (e) {
-                if (mounted) {
-                  print(e);
-                }
+                print(e);
               } finally {
-                if (mounted) {
-                  setState(() => _isLoading = false);
-                }
+                setState(() => _isLoading = false);
               }
             },
           ),
@@ -120,9 +116,7 @@ class _DownloadPreplannedMapAreaSampleState
     }
 
     _offlineMapTask = offlineMapTask;
-    if (mounted) {
-      setState(() => _preplannedAreas = preplannedAreas);
-    }
+    setState(() => _preplannedAreas = preplannedAreas);
   }
 
   Future<ArcGISMap?> _downloadOfflineMap(int preplannedAreaIndex) async {

--- a/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
+++ b/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
@@ -22,6 +22,8 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class DownloadPreplannedMapAreaSample extends StatefulWidget {
   const DownloadPreplannedMapAreaSample({super.key});
 
@@ -31,7 +33,7 @@ class DownloadPreplannedMapAreaSample extends StatefulWidget {
 }
 
 class _DownloadPreplannedMapAreaSampleState
-    extends State<DownloadPreplannedMapAreaSample> {
+    extends State<DownloadPreplannedMapAreaSample> with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
   var _preplannedAreas = <PreplannedMapArea>[];
   var _selectedPreplannedAreaIndex = -1;

--- a/lib/samples/filter_by_definition_expression_or_display_filter/filter_by_definition_expression_or_display_filter_sample.dart
+++ b/lib/samples/filter_by_definition_expression_or_display_filter/filter_by_definition_expression_or_display_filter_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class FilterByDefinitionExpressionOrDisplayFilterSample extends StatefulWidget {
   const FilterByDefinitionExpressionOrDisplayFilterSample({super.key});
 
@@ -26,7 +28,8 @@ class FilterByDefinitionExpressionOrDisplayFilterSample extends StatefulWidget {
 }
 
 class _FilterByDefinitionExpressionOrDisplayFilterSampleState
-    extends State<FilterByDefinitionExpressionOrDisplayFilterSample> {
+    extends State<FilterByDefinitionExpressionOrDisplayFilterSample>
+    with SampleStateSupport {
   // create a map view controller
   final _mapViewController = ArcGISMapView.createController();
   // create a feature layer

--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class FindAddressWithReverseGeocodeSample extends StatefulWidget {
   const FindAddressWithReverseGeocodeSample({super.key});
 
@@ -26,7 +28,7 @@ class FindAddressWithReverseGeocodeSample extends StatefulWidget {
 }
 
 class _FindAddressWithReverseGeocodeSampleState
-    extends State<FindAddressWithReverseGeocodeSample> {
+    extends State<FindAddressWithReverseGeocodeSample> with SampleStateSupport {
   final _graphicsOverlay = GraphicsOverlay();
   final _worldLocatorTask = LocatorTask.withUri(Uri.parse(
       'https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer'));

--- a/lib/samples/find_closest_facility_from_point/find_closest_facility_from_point_sample.dart
+++ b/lib/samples/find_closest_facility_from_point/find_closest_facility_from_point_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class FindClosestFacilityFromPointSample extends StatefulWidget {
   const FindClosestFacilityFromPointSample({super.key});
 
@@ -26,7 +28,7 @@ class FindClosestFacilityFromPointSample extends StatefulWidget {
 }
 
 class _FindClosestFacilityFromPointSampleState
-    extends State<FindClosestFacilityFromPointSample> {
+    extends State<FindClosestFacilityFromPointSample> with SampleStateSupport {
   static final _fireStationImageUri = Uri.parse(
       'https://static.arcgis.com/images/Symbols/SafetyHealth/FireStation.png');
   static final _fireImageUri = Uri.parse(

--- a/lib/samples/find_closest_facility_from_point/find_closest_facility_from_point_sample.dart
+++ b/lib/samples/find_closest_facility_from_point/find_closest_facility_from_point_sample.dart
@@ -115,9 +115,7 @@ class _FindClosestFacilityFromPointSampleState
     _closestFacilityParameters = await generateClosestFacilityParameters(
         facilitiesLayer, incidentsLayer);
 
-    if (mounted) {
-      setState(() => _isInitialized = true);
-    }
+    setState(() => _isInitialized = true);
   }
 
   FeatureLayer buildFeatureLayer(Uri tableUri, Uri imageUri) {
@@ -175,9 +173,7 @@ class _FindClosestFacilityFromPointSampleState
         _routeGraphicsOverlay.graphics.add(routeGraphic);
       }
     }
-    if (mounted) {
-      setState(() => _isRouteSolved = true);
-    }
+    setState(() => _isRouteSolved = true);
   }
 
   void resetRoutes() {

--- a/lib/samples/find_route/find_route_sample.dart
+++ b/lib/samples/find_route/find_route_sample.dart
@@ -100,10 +100,7 @@ class _FindRouteSampleState extends State<FindRouteSample>
     initMap();
     initStops();
     await initRouteParameters();
-    if (mounted) {
-      //fixme
-      setState(() => _ready = true);
-    }
+    setState(() => _ready = true);
   }
 
   void initMap() {
@@ -214,12 +211,10 @@ class _FindRouteSampleState extends State<FindRouteSample>
       _routeGraphicsOverlay.graphics.add(routeGraphic);
     }
 
-    if (mounted) {
-      setState(() {
-        _directions = route.directionManeuvers;
-        _routeGenerated = true;
-      });
-    }
+    setState(() {
+      _directions = route.directionManeuvers;
+      _routeGenerated = true;
+    });
   }
 
   Dialog showDirections(BuildContext context) {

--- a/lib/samples/find_route/find_route_sample.dart
+++ b/lib/samples/find_route/find_route_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class FindRouteSample extends StatefulWidget {
   const FindRouteSample({super.key});
 
@@ -24,7 +26,8 @@ class FindRouteSample extends StatefulWidget {
   State<FindRouteSample> createState() => _FindRouteSampleState();
 }
 
-class _FindRouteSampleState extends State<FindRouteSample> {
+class _FindRouteSampleState extends State<FindRouteSample>
+    with SampleStateSupport {
   // the map view controller.
   final _mapViewController = ArcGISMapView.createController();
   // the graphics overlay for the stops.
@@ -98,6 +101,7 @@ class _FindRouteSampleState extends State<FindRouteSample> {
     initStops();
     await initRouteParameters();
     if (mounted) {
+      //fixme
       setState(() => _ready = true);
     }
   }

--- a/lib/samples/identify_layer_features/identify_layer_features_sample.dart
+++ b/lib/samples/identify_layer_features/identify_layer_features_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class IdentifyLayerFeaturesSample extends StatefulWidget {
   const IdentifyLayerFeaturesSample({super.key});
 
@@ -26,7 +28,7 @@ class IdentifyLayerFeaturesSample extends StatefulWidget {
 }
 
 class _IdentifyLayerFeaturesSampleState
-    extends State<IdentifyLayerFeaturesSample> {
+    extends State<IdentifyLayerFeaturesSample> with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
 
   @override

--- a/lib/samples/query_feature_table/query_feature_table_sample.dart
+++ b/lib/samples/query_feature_table/query_feature_table_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class QueryFeatureTableSample extends StatefulWidget {
   const QueryFeatureTableSample({super.key});
 
@@ -25,7 +27,8 @@ class QueryFeatureTableSample extends StatefulWidget {
       _QueryFeatureTableSampleState();
 }
 
-class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample> {
+class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample>
+    with SampleStateSupport {
   // create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
   // create a text editing controller.

--- a/lib/samples/query_table_statistics/query_table_statistics_sample.dart
+++ b/lib/samples/query_table_statistics/query_table_statistics_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class QueryTableStatisticsSample extends StatefulWidget {
   const QueryTableStatisticsSample({super.key});
 
@@ -25,8 +27,8 @@ class QueryTableStatisticsSample extends StatefulWidget {
       _QueryTableStatisticsSampleState();
 }
 
-class _QueryTableStatisticsSampleState
-    extends State<QueryTableStatisticsSample> {
+class _QueryTableStatisticsSampleState extends State<QueryTableStatisticsSample>
+    with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
   final _serviceFeatureTable = ServiceFeatureTable.withUri(Uri.parse(
       'https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer/0'));

--- a/lib/samples/search_with_geocode/search_with_geocode_sample.dart
+++ b/lib/samples/search_with_geocode/search_with_geocode_sample.dart
@@ -169,9 +169,7 @@ class _SearchWithGeocodeSampleState extends State<SearchWithGeocodeSample>
 
     final suggestResults = await _suggestOperation!.value;
     _suggestOperation = null;
-    if (mounted) {
-      setState(() => _suggestResults = List.from(suggestResults));
-    }
+    setState(() => _suggestResults = List.from(suggestResults));
 
     if (_suggestAgain != null) {
       // start again with the latest input value

--- a/lib/samples/search_with_geocode/search_with_geocode_sample.dart
+++ b/lib/samples/search_with_geocode/search_with_geocode_sample.dart
@@ -18,6 +18,8 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class SearchWithGeocodeSample extends StatefulWidget {
   const SearchWithGeocodeSample({super.key});
 
@@ -26,7 +28,8 @@ class SearchWithGeocodeSample extends StatefulWidget {
       _SearchWithGeocodeSampleState();
 }
 
-class _SearchWithGeocodeSampleState extends State<SearchWithGeocodeSample> {
+class _SearchWithGeocodeSampleState extends State<SearchWithGeocodeSample>
+    with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController()
     ..arcGISMap = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISImagery);
 

--- a/lib/samples/select_features_in_feature_layer/select_features_in_feature_layer_sample.dart
+++ b/lib/samples/select_features_in_feature_layer/select_features_in_feature_layer_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class SelectFeaturesInFeatureLayerSample extends StatefulWidget {
   const SelectFeaturesInFeatureLayerSample({super.key});
 
@@ -26,7 +28,7 @@ class SelectFeaturesInFeatureLayerSample extends StatefulWidget {
 }
 
 class _SelectFeaturesInFeatureLayerSampleState
-    extends State<SelectFeaturesInFeatureLayerSample> {
+    extends State<SelectFeaturesInFeatureLayerSample> with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
   final _featureLayer = FeatureLayer.withFeatureTable(
       ServiceFeatureTable.withUri(Uri.parse(

--- a/lib/samples/set_basemap/set_basemap_sample.dart
+++ b/lib/samples/set_basemap/set_basemap_sample.dart
@@ -19,7 +19,9 @@ import 'dart:async';
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
+
 import '../../utils/sample_data.dart';
+import '../../utils/sample_state_support.dart';
 
 class SetBasemapSample extends StatefulWidget {
   const SetBasemapSample({super.key});
@@ -28,7 +30,8 @@ class SetBasemapSample extends StatefulWidget {
   State<SetBasemapSample> createState() => _SetBasemapSampleState();
 }
 
-class _SetBasemapSampleState extends State<SetBasemapSample> {
+class _SetBasemapSampleState extends State<SetBasemapSample>
+    with SampleStateSupport {
   final GlobalKey<ScaffoldState> _scaffoldStateKey = GlobalKey();
 
   final _mapViewController = ArcGISMapView.createController();

--- a/lib/samples/show_device_location/show_device_location_sample.dart
+++ b/lib/samples/show_device_location/show_device_location_sample.dart
@@ -19,6 +19,8 @@ import 'dart:async';
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ShowDeviceLocationSample extends StatefulWidget {
   const ShowDeviceLocationSample({super.key});
 
@@ -27,7 +29,8 @@ class ShowDeviceLocationSample extends StatefulWidget {
       _ShowDeviceLocationSampleState();
 }
 
-class _ShowDeviceLocationSampleState extends State<ShowDeviceLocationSample> {
+class _ShowDeviceLocationSampleState extends State<ShowDeviceLocationSample>
+    with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
   double _latitude = 0.0;
   double _longitude = 0.0;

--- a/lib/samples/show_device_location_history/show_device_location_history_sample.dart
+++ b/lib/samples/show_device_location_history/show_device_location_history_sample.dart
@@ -20,6 +20,8 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ShowDeviceLocationHistorySample extends StatefulWidget {
   const ShowDeviceLocationHistorySample({super.key});
 
@@ -29,7 +31,7 @@ class ShowDeviceLocationHistorySample extends StatefulWidget {
 }
 
 class _ShowDeviceLocationHistorySampleState
-    extends State<ShowDeviceLocationHistorySample> {
+    extends State<ShowDeviceLocationHistorySample> with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
   double _latitude = 0.0;
   double _longitude = 0.0;

--- a/lib/samples/show_service_area/show_service_area_sample.dart
+++ b/lib/samples/show_service_area/show_service_area_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class ShowServiceAreaSample extends StatefulWidget {
   const ShowServiceAreaSample({super.key});
 
@@ -24,7 +26,8 @@ class ShowServiceAreaSample extends StatefulWidget {
   State<ShowServiceAreaSample> createState() => _ShowServiceAreaSampleState();
 }
 
-class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample> {
+class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
+    with SampleStateSupport {
   // create a map view controller
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/style_point_with_simple_marker_symbol/style_point_with_simple_marker_symbol_sample.dart
+++ b/lib/samples/style_point_with_simple_marker_symbol/style_point_with_simple_marker_symbol_sample.dart
@@ -17,6 +17,8 @@
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/sample_state_support.dart';
+
 class StylePointWithSimpleMarkerSymbolSample extends StatefulWidget {
   const StylePointWithSimpleMarkerSymbolSample({super.key});
 
@@ -26,7 +28,8 @@ class StylePointWithSimpleMarkerSymbolSample extends StatefulWidget {
 }
 
 class _StylePointWithSimpleMarkerSymbolSampleState
-    extends State<StylePointWithSimpleMarkerSymbolSample> {
+    extends State<StylePointWithSimpleMarkerSymbolSample>
+    with SampleStateSupport {
   final _mapViewController = ArcGISMapView.createController();
 
   @override

--- a/lib/utils/sample_state_support.dart
+++ b/lib/utils/sample_state_support.dart
@@ -1,0 +1,24 @@
+//
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:flutter/material.dart';
+
+mixin SampleStateSupport<T extends StatefulWidget> on State<T> {
+  @override
+  void setState(VoidCallback fn) {
+    if (mounted) super.setState(fn);
+  }
+}

--- a/lib/utils/sample_state_support.dart
+++ b/lib/utils/sample_state_support.dart
@@ -16,6 +16,8 @@
 
 import 'package:flutter/material.dart';
 
+/// A mixin that overrides `setState` to first check if the widget is mounted.
+/// (Calling `setState` on an unmounted widget causes an exception.)
 mixin SampleStateSupport<T extends StatefulWidget> on State<T> {
   @override
   void setState(VoidCallback fn) {


### PR DESCRIPTION
A new mixin, `SampleStateSupport`, provides an override for "setState" that checks if the widget is still mounted before setting the state. All samples should use `with SampleStateSupport` to get this behaviour transparently.

Also, remove some now-obsolete "mounted" checks.