### PR TITLE
Apply progress indicators to samples

### DIFF
--- a/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
+++ b/lib/samples/add_tiled_layer_as_basemap/add_tiled_layer_as_basemap_sample.dart
@@ -33,14 +33,30 @@ class AddTiledLayerAsBasemapSampleState
     extends State<AddTiledLayerAsBasemapSample> with SampleStateSupport {
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
+  // A flag for when the map view is ready.
+  var _ready = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       // Add a map view to the widget tree and set a controller.
-      body: ArcGISMapView(
-        controllerProvider: () => _mapViewController,
-        onMapViewReady: onMapViewReady,
+      body: Stack(
+        children: [
+          ArcGISMapView(
+            controllerProvider: () => _mapViewController,
+            onMapViewReady: onMapViewReady,
+          ),
+          // Display a progress indicator and prevent interaction until state is ready.
+          Visibility(
+            visible: !_ready,
+            child: SizedBox.expand(
+              child: Container(
+                color: Colors.white30,
+                child: const Center(child: CircularProgressIndicator()),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -62,5 +78,7 @@ class AddTiledLayerAsBasemapSampleState
     final map = ArcGISMap.withBasemap(basemap);
     // Set the map to the map view.
     _mapViewController.arcGISMap = map;
+    // Set the ready state variable to true to enable the UI.
+    setState(() => _ready = true);
   }
 }

--- a/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
+++ b/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
@@ -46,23 +46,37 @@ class _ApplyClassBreaksRendererToSublayerSampleState
     return Scaffold(
       body: SafeArea(
         top: false,
-        child: Column(
-          // Add the map view and buttons to a column.
+        child: Stack(
           children: [
-            Expanded(
-              // Add a map view to the widget tree and set a controller.
-              child: ArcGISMapView(
-                controllerProvider: () => _mapViewController,
-                onMapViewReady: onMapViewReady,
+            Column(
+              // Add the map view and buttons to a column.
+              children: [
+                Expanded(
+                  // Add a map view to the widget tree and set a controller.
+                  child: ArcGISMapView(
+                    controllerProvider: () => _mapViewController,
+                    onMapViewReady: onMapViewReady,
+                  ),
+                ),
+                Center(
+                  // Apply renderer button.
+                  child: ElevatedButton(
+                    onPressed: !_rendered ? renderLayer : null,
+                    child: const Text('Change Sublayer Renderer'),
+                  ),
+                )
+              ],
+            ),
+            // Display a progress indicator and prevent interaction until state is ready.
+            Visibility(
+              visible: !_ready,
+              child: SizedBox.expand(
+                child: Container(
+                  color: Colors.white30,
+                  child: const Center(child: CircularProgressIndicator()),
+                ),
               ),
             ),
-            Center(
-              // Apply renderer button.
-              child: ElevatedButton(
-                onPressed: _ready && !_rendered ? renderLayer : null,
-                child: const Text('Change Sublayer Renderer'),
-              ),
-            )
           ],
         ),
       ),

--- a/lib/samples/display_clusters/display_clusters_sample.dart
+++ b/lib/samples/display_clusters/display_clusters_sample.dart
@@ -39,20 +39,34 @@ class _DisplayClustersSampleState extends State<DisplayClustersSample>
     return Scaffold(
       body: SafeArea(
         top: false,
-        child: Column(
+        child: Stack(
           children: [
-            Expanded(
-              // Add a map view to the widget tree and set a controller.
-              child: ArcGISMapView(
-                controllerProvider: () => _mapViewController,
-                onMapViewReady: onMapViewReady,
-              ),
+            Column(
+              children: [
+                Expanded(
+                  // Add a map view to the widget tree and set a controller.
+                  child: ArcGISMapView(
+                    controllerProvider: () => _mapViewController,
+                    onMapViewReady: onMapViewReady,
+                  ),
+                ),
+                Center(
+                  // Create a button to toggle feature clustering.
+                  child: ElevatedButton(
+                    onPressed: toggleFeatureClustering,
+                    child: const Text('Toggle feature clustering'),
+                  ),
+                ),
+              ],
             ),
-            Center(
-              // Create a button to toggle feature clustering.
-              child: ElevatedButton(
-                onPressed: _ready ? toggleFeatureClustering : null,
-                child: const Text('Toggle feature clustering'),
+            // Display a progress indicator and prevent interaction until state is ready.
+            Visibility(
+              visible: !_ready,
+              child: SizedBox.expand(
+                child: Container(
+                  color: Colors.white30,
+                  child: const Center(child: CircularProgressIndicator()),
+                ),
               ),
             ),
           ],

--- a/lib/samples/display_map_from_mobile_map_package/display_map_from_mobile_map_package_sample.dart
+++ b/lib/samples/display_map_from_mobile_map_package/display_map_from_mobile_map_package_sample.dart
@@ -36,14 +36,30 @@ class _DisplayMapFromMobileMapPackageSampleState
     with SampleStateSupport {
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
+  // A flag for when the map view is ready.
+  var _ready = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       // Add a map view to the widget tree and set a controller.
-      body: ArcGISMapView(
-        controllerProvider: () => _mapViewController,
-        onMapViewReady: onMapViewReady,
+      body: Stack(
+        children: [
+          ArcGISMapView(
+            controllerProvider: () => _mapViewController,
+            onMapViewReady: onMapViewReady,
+          ),
+          // Display a progress indicator and prevent interaction until state is ready.
+          Visibility(
+            visible: !_ready,
+            child: SizedBox.expand(
+              child: Container(
+                color: Colors.white30,
+                child: const Center(child: CircularProgressIndicator()),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -61,5 +77,8 @@ class _DisplayMapFromMobileMapPackageSampleState
       // Get the first map in the mobile map package and set to the map view.
       _mapViewController.arcGISMap = mmpk.maps.first;
     }
+
+    // Set the ready state variable to true to enable the sample UI.
+    setState(() => _ready = true);
   }
 }

--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
@@ -54,7 +54,17 @@ class _FindAddressWithReverseGeocodeSampleState
           ArcGISMapView(
             controllerProvider: () => _mapViewController,
             onMapViewReady: onMapViewReady,
-            onTap: _ready ? onTap : null,
+            onTap: onTap,
+          ),
+          // Display a progress indicator and prevent interaction until state is ready.
+          Visibility(
+            visible: !_ready,
+            child: SizedBox.expand(
+              child: Container(
+                color: Colors.white30,
+                child: const Center(child: CircularProgressIndicator()),
+              ),
+            ),
           ),
         ],
       ),
@@ -83,8 +93,6 @@ class _FindAddressWithReverseGeocodeSampleState
 
     // Load the locator task and once loaded set the _ready flag to true to enable the UI.
     await _worldLocatorTask.load();
-
-    // Set the ready state variable to true to enable the sample UI.
     setState(() => _ready = true);
   }
 

--- a/lib/samples/find_route/find_route_sample.dart
+++ b/lib/samples/find_route/find_route_sample.dart
@@ -53,43 +53,56 @@ class _FindRouteSampleState extends State<FindRouteSample>
     return Scaffold(
       body: SafeArea(
         top: false,
-        // Create a column with buttons for generating the route and showing the directions.
-        child: Column(
+        child: Stack(
           children: [
-            Expanded(
-              // Add a map view to the widget tree and set a controller.
-              child: ArcGISMapView(
-                controllerProvider: () => _mapViewController,
-                onMapViewReady: onMapViewReady,
+            // Create a column with buttons for generating the route and showing the directions.
+            Column(
+              children: [
+                Expanded(
+                  // Add a map view to the widget tree and set a controller.
+                  child: ArcGISMapView(
+                    controllerProvider: () => _mapViewController,
+                    onMapViewReady: onMapViewReady,
+                  ),
+                ),
+                SizedBox(
+                  height: 60,
+                  // Add the buttons to the column.
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      // Create a button to generate the route.
+                      ElevatedButton(
+                        onPressed:
+                            _routeGenerated ? null : () => generateRoute(),
+                        child: const Text('Route'),
+                      ),
+                      // Create a button to show the directions.
+                      ElevatedButton(
+                        onPressed: _routeGenerated
+                            ? () => showDialog(
+                                  context: context,
+                                  builder: (context) => showDirections(context),
+                                )
+                            : null,
+                        child: const Text('Directions'),
+                      ),
+                    ],
+                  ),
+                )
+              ],
+            ),
+            // Display a progress indicator and prevent interaction until state is ready.
+            Visibility(
+              visible: !_ready,
+              child: SizedBox.expand(
+                child: Container(
+                  color: Colors.white30,
+                  child: const Center(child: CircularProgressIndicator()),
+                ),
               ),
             ),
-            SizedBox(
-              height: 60,
-              // Add the buttons to the column.
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  // Create a button to generate the route.
-                  ElevatedButton(
-                    onPressed: _routeGenerated || !_ready
-                        ? null
-                        : () => generateRoute(),
-                    child: const Text('Route'),
-                  ),
-                  // Create a button to show the directions.
-                  ElevatedButton(
-                    onPressed: _routeGenerated
-                        ? () => showDialog(
-                              context: context,
-                              builder: (context) => showDirections(context),
-                            )
-                        : null,
-                    child: const Text('Directions'),
-                  ),
-                ],
-              ),
-            )
           ],
         ),
       ),

--- a/lib/samples/show_service_area/show_service_area_sample.dart
+++ b/lib/samples/show_service_area/show_service_area_sample.dart
@@ -57,9 +57,13 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
       'https://route-api.arcgis.com/arcgis/rest/services/World/ServiceAreas/NAServer/ServiceArea_World'));
   late final ServiceAreaParameters _serviceAreaParameters;
 
+  // A state variable for controlling the segmented button selection.
+  var _segmentedButtonSelection = Selection.facility;
+
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
-  var _segmentedButtonSelection = Selection.facility;
+  // A flag for when the service area task is in progress.
+  var _taskInProgress = false;
 
   @override
   Widget build(BuildContext context) {
@@ -75,7 +79,7 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
                   child: ArcGISMapView(
                     controllerProvider: () => _mapViewController,
                     onMapViewReady: onMapViewReady,
-                    onTap: _ready ? onTap : null,
+                    onTap: onTap,
                   ),
                 ),
                 SizedBox(
@@ -106,11 +110,11 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
                       ),
                       // Create buttons for calculating the service area and resetting.
                       TextButton(
-                        onPressed: _ready ? solveServiceArea : null,
+                        onPressed: solveServiceArea,
                         child: const Text('Service Areas'),
                       ),
                       TextButton(
-                        onPressed: _ready ? resetServiceArea : null,
+                        onPressed: resetServiceArea,
                         child: const Text('Reset'),
                       ),
                     ],
@@ -120,8 +124,13 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
             ),
             // Display a progress indicator when the ready flag is false - this will indicate the map is loading or the service area task is in progress.
             Visibility(
-              visible: !_ready,
-              child: const Center(child: CircularProgressIndicator()),
+              visible: !_ready || _taskInProgress,
+              child: SizedBox.expand(
+                child: Container(
+                  color: Colors.white30,
+                  child: const Center(child: CircularProgressIndicator()),
+                ),
+              ),
             ),
           ],
         ),
@@ -192,7 +201,7 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
     // Require at least 1 facility to perform a service area calculation.
     if (_facilityGraphicsOverlay.graphics.isNotEmpty) {
       // Disable the UI while the service area is calculated.
-      setState(() => _ready = false);
+      setState(() => _taskInProgress = true);
       // Clear previous calculations.
       _serviceAreaGraphicsOverlay.graphics.clear();
 
@@ -230,7 +239,7 @@ class _ShowServiceAreaSampleState extends State<ShowServiceAreaSample>
       }
 
       // Re-enable the UI once the service area task is finished.
-      setState(() => _ready = true);
+      setState(() => _taskInProgress = false);
     } else {
       showDialog(
         context: context,


### PR DESCRIPTION
In this PR I focused on applying progress indicators, or aligning existing progress indicators with our workflow.

It affects:
- Show Service Area
- Find Route
- Find Address With Reverse Geocode
- Display Map From Mobile Map Package
- Display Clusters
- Apply Class Breaks Renderer To Sublayer
- Add Tiled Layer As Basemap

Note that the samples that have not yet had common designs applied we'll come back to once the common design is applied to avoid duplication of effort.