### PR TITLE
Apply patterns to existing samples

### DIFF
--- a/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
+++ b/lib/samples/apply_class_breaks_renderer_to_sublayer/apply_class_breaks_renderer_to_sublayer_sample.dart
@@ -103,11 +103,11 @@ class _ApplyClassBreaksRendererToSublayerSampleState
 
   ClassBreaksRenderer createPopulationClassBreaksRenderer() {
     // Create colors for the class breaks.
-    var blue1 = const Color.fromARGB(255, 153, 206, 231);
-    var blue2 = const Color.fromARGB(255, 108, 192, 232);
-    var blue3 = const Color.fromARGB(255, 77, 173, 218);
-    var blue4 = const Color.fromARGB(255, 28, 130, 178);
-    var blue5 = const Color.fromARGB(255, 2, 75, 109);
+    const blue1 = Color.fromARGB(255, 153, 206, 231);
+    const blue2 = Color.fromARGB(255, 108, 192, 232);
+    const blue3 = Color.fromARGB(255, 77, 173, 218);
+    const blue4 = Color.fromARGB(255, 28, 130, 178);
+    const blue5 = Color.fromARGB(255, 2, 75, 109);
 
     // Create symbols for the class breaks.
     final outline = SimpleLineSymbol(

--- a/lib/samples/display_clusters/display_clusters_sample.dart
+++ b/lib/samples/display_clusters/display_clusters_sample.dart
@@ -32,7 +32,7 @@ class _DisplayClustersSampleState extends State<DisplayClustersSample>
   final _mapViewController = ArcGISMapView.createController();
   late ArcGISMap _map;
   // A flag for when the map view is ready and controls can be used.
-  bool _ready = false;
+  var _ready = false;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode_sample.dart
@@ -43,7 +43,7 @@ class _FindAddressWithReverseGeocodeSampleState
     scale: 5e4,
   );
   // A flag for when the map view is ready and controls can be used.
-  bool _ready = false;
+  var _ready = false;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/samples/style_point_with_simple_marker_symbol/style_point_with_simple_marker_symbol_sample.dart
+++ b/lib/samples/style_point_with_simple_marker_symbol/style_point_with_simple_marker_symbol_sample.dart
@@ -30,12 +30,21 @@ class StylePointWithSimpleMarkerSymbolSample extends StatefulWidget {
 class _StylePointWithSimpleMarkerSymbolSampleState
     extends State<StylePointWithSimpleMarkerSymbolSample>
     with SampleStateSupport {
+  // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 
   @override
-  void initState() {
-    super.initState();
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // Add a map view to the widget tree and set a controller.
+      body: ArcGISMapView(
+        controllerProvider: () => _mapViewController,
+        onMapViewReady: _onMapViewReady,
+      ),
+    );
+  }
 
+  void _onMapViewReady() {
     // Create a map with a basemap style.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISImageryStandard);
 
@@ -68,15 +77,5 @@ class _StylePointWithSimpleMarkerSymbolSampleState
 
     // Add the graphic to the graphics overlay.
     graphicsOverlay.graphics.add(graphic);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      // Add a map view to the widget tree and set a controller.
-      body: ArcGISMapView(
-        controllerProvider: () => _mapViewController,
-      ),
-    );
   }
 }


### PR DESCRIPTION
In this PR I capture some more of the desired patterns in existing samples.

- Moving setup from `initState` to `onMapViewReady`
- bool -> var
- var -> final/const

I have also checked the following patterns and identified no required changes:
- Use of `Scaffold`, `SafeArea`, `Column`, `Expanded`
- Use of `SafeArea` `top: false`
- class variables with `_`

Affected samples:
- Apply class breaks renderer to sublayer
- display clusters
- find address with reverse geocode
- style point with simple marker symbol

A separate PR will follow to cover use of `ElevatedButton` and `Row.spaceEvenly`