### PR TITLE
Clean up the README for Show Portal User Info

### DIFF
--- a/lib/samples/show_portal_user_info/README.md
+++ b/lib/samples/show_portal_user_info/README.md
@@ -20,21 +20,22 @@ When prompted, enter your ArcGIS Online credentials.
 4. The `ArcGISAuthenticationChallengeHandler` callback is called to handle the authentication challenge.
 5. The OAuth login process is triggered using `OAuthUserCredential.create()`.
 
-If the portal is successfully loaded, the `portalUser` property is used to populate a series of fields including:
+If the portal is successfully loaded, the `user` property is used to populate a series of fields including:
 
-* fullName
-* username
-* email
-* description
-* access
+* `fullName`
+* `username`
+* `email`
+* `thumbnail`
+* `userDescription`
+* `access`
 
 Similarly, the `portalInfo` property is used to populate:
 
-* organizationName
-* organizationDescription
-* thumbnailUrl
-* canSearchPublic
-* canSharePublic
+* `organizationName`
+* `organizationDescription`
+* `thumbnail`
+* `canSearchPublic`
+* `canSharePublic`
 
 ## Relevant API
 


### PR DESCRIPTION
The bulleted lists in the design have `backticks` for formatting. Also, some of the property names are slightly different once they hit the API -- e.g., "thumbnailUrl" is just "thumbnail".