### PR TITLE
Update redirect for OAuth

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="my-ags-app" />
+                <data android:scheme="my-ags-flutter-app" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/samples/authenticate_with_oauth/authenticate_with_oauth_sample.dart
+++ b/lib/samples/authenticate_with_oauth/authenticate_with_oauth_sample.dart
@@ -35,8 +35,8 @@ class _AuthenticateWithOAuthSampleState
   // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/user-authentication/serverless-native-flow/
   final _oauthUserConfiguration = OAuthUserConfiguration(
     portalUri: Uri.parse('https://www.arcgis.com'),
-    clientId: 'lgAdHkYZYlwwfAhC',
-    redirectUri: Uri.parse('my-ags-app://auth'),
+    clientId: 'T0A3SudETrIQndd2',
+    redirectUri: Uri.parse('my-ags-flutter-app://auth'),
   );
   final _mapViewController = ArcGISMapView.createController();
 

--- a/lib/samples/show_portal_user_info/show_portal_user_info_sample.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info_sample.dart
@@ -20,8 +20,8 @@ class _ShowPortalUserInfoSampleState extends State<ShowPortalUserInfoSample>
   // https://developers.arcgis.com/documentation/mapping-apis-and-services/security/user-authentication/serverless-native-flow/
   final _oauthUserConfiguration = OAuthUserConfiguration(
     portalUri: Uri.parse('https://www.arcgis.com'),
-    clientId: 'lgAdHkYZYlwwfAhC',
-    redirectUri: Uri.parse('my-ags-app://auth'),
+    clientId: 'T0A3SudETrIQndd2',
+    redirectUri: Uri.parse('my-ags-flutter-app://auth'),
   );
   // Create a Portal that requires authentication.
   final _portal =


### PR DESCRIPTION
Updates to a unique OAuth redirect to avoid clash with other SDK sample viewers on same device. I created a separate OAuth credential so also updates the clientId.