### PR TITLE
Remove loadable image extension

### DIFF
--- a/lib/samples/show_portal_user_info/show_portal_user_info_sample.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info_sample.dart
@@ -158,11 +158,3 @@ class _ShowPortalUserInfoSampleState extends State<ShowPortalUserInfoSample>
     });
   }
 }
-
-extension on LoadableImage {
-  // A helper method to load the image bytes.
-  Future<Uint8List> loadBytes() async {
-    await load();
-    return image!.getEncodedBuffer();
-  }
-}


### PR DESCRIPTION
`LoadableImage` now defines the `loadBytes` function. The extension in the Show portal user info sample is no longer needed.