### PR TITLE
Escape single quotes in user input

### DIFF
--- a/lib/samples/query_feature_table/query_feature_table_sample.dart
+++ b/lib/samples/query_feature_table/query_feature_table_sample.dart
@@ -123,8 +123,8 @@ class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample>
 
     // Create query parameters and set the where clause.
     final queryParameters = QueryParameters();
-    final stateName = value.trim().toUpperCase();
-    queryParameters.whereClause = "upper(STATE_NAME) LIKE '$stateName'";
+    final stateName = value.trim().toUpperCase().replaceAll("'", "''");
+    queryParameters.whereClause = "UPPER(STATE_NAME) LIKE '$stateName%'";
 
     // Query the feature table with the query parameters.
     final queryResult =

--- a/lib/samples/query_feature_table/query_feature_table_sample.dart
+++ b/lib/samples/query_feature_table/query_feature_table_sample.dart
@@ -123,8 +123,9 @@ class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample>
 
     // Create query parameters and set the where clause.
     final queryParameters = QueryParameters();
-    final stateName = value.trim().toUpperCase().replaceAll("'", "''");
-    queryParameters.whereClause = "upper(STATE_NAME) LIKE '$stateName%'";
+    final stateName = value.trim();
+    queryParameters.whereClause =
+        "upper(STATE_NAME) LIKE '${stateName.toUpperCase().sqlEscape()}%'";
 
     // Query the feature table with the query parameters.
     final queryResult =
@@ -164,4 +165,10 @@ class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample>
     setState(() => _textEditingController.clear());
     FocusManager.instance.primaryFocus?.unfocus();
   }
+}
+
+extension on String {
+  // Prepare a string so that it can be used as input in a whereClause, which must
+  // be valid SQL.
+  String sqlEscape() => replaceAll("'", "''");
 }

--- a/lib/samples/query_feature_table/query_feature_table_sample.dart
+++ b/lib/samples/query_feature_table/query_feature_table_sample.dart
@@ -124,7 +124,7 @@ class _QueryFeatureTableSampleState extends State<QueryFeatureTableSample>
     // Create query parameters and set the where clause.
     final queryParameters = QueryParameters();
     final stateName = value.trim().toUpperCase().replaceAll("'", "''");
-    queryParameters.whereClause = "UPPER(STATE_NAME) LIKE '$stateName%'";
+    queryParameters.whereClause = "upper(STATE_NAME) LIKE '$stateName%'";
 
     // Query the feature table with the query parameters.
     final queryResult =


### PR DESCRIPTION
The 'single quote' is a special character in SQL, so we have to replace them with a pair of single quotes when using user input as part of a `whereClause`.

Also, I reviewed the other SDKs versions of this sample. They use `%` to allow substring matches. So I added a `%` at the end of our query, so that e.g., `Calif` matches `California` and so forth.