### PR TITLE
Fix narrow offline maps in Generate offline map sample

### DIFF
--- a/lib/samples/generate_offline_map/generate_offline_map_sample.dart
+++ b/lib/samples/generate_offline_map/generate_offline_map_sample.dart
@@ -157,6 +157,9 @@ class _GenerateOfflineMapSampleState extends State<GenerateOfflineMapSample>
     _map = ArcGISMap.withItem(portalItem);
     _mapViewController.arcGISMap = _map;
 
+    // Offline map generation does not consider rotation, so disable it.
+    _mapViewController.interactionOptions.rotateEnabled = false;
+
     // Create an OfflineMapTask for the map.
     _offlineMapTask = OfflineMapTask.withOnlineMap(_map);
 


### PR DESCRIPTION
Judging by the screenshots in the issue, the tester was accidentally rotating the map as they panned and zoomed. Rotating the map led to an incorrect mapping of the red outline envelope to the map. This caused the generated map to be incorrect.

To correct the issue, map rotation was disabled. This is the easiest solution and offline map generation does not take rotation into consideration. The Swift sample app is doing the same.