### PR TITLE
Fix: Download Preplanned Map Area

### DIFF
--- a/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
+++ b/lib/samples/download_preplanned_map_area/download_preplanned_map_area_sample.dart
@@ -180,7 +180,7 @@ class _DownloadPreplannedMapAreaSampleState
             trailing: _mapViewController.arcGISMap == _webMap
                 ? const Icon(Icons.check)
                 : null,
-            onTap: () => _mapViewController.arcGISMap == _webMap
+            onTap: () => _mapViewController.arcGISMap != _webMap
                 ? setMapAndViewpoint(_webMap)
                 : null,
           ),


### PR DESCRIPTION
Had the logic upside down, this PR fixes the webmap selection tile.