### PR TITLE
Cs/1561 follow up-Disable the map view rotation

### DIFF
--- a/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
+++ b/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
@@ -116,6 +116,9 @@ class _DownloadVectorTilesToLocalCacheState
 
   // the method to be called when the map view is ready
   void onMapViewReady() {
+    // disable the map view's rotation.
+    _mapViewController.interactionOptions.rotateEnabled = false;
+
     setupInitialMapView();
     // Set the ready state variable to true to enable the sample UI.
     setState(() => _ready = true);


### PR DESCRIPTION
disable the map view rotation to avoid the map view becoming 'thin'.