### PR TITLE
Cut Geometry correction

### DIFF
--- a/assets/generated_samples_list.json
+++ b/assets/generated_samples_list.json
@@ -503,7 +503,7 @@
       "Polyline"
     ],
     "snippets": [
-      "cut_geometry_sample.dart"
+      "cut_geometry.dart"
     ],
     "title": "Cut geometry",
     "key": "cut_geometry"

--- a/lib/samples/cut_geometry/README.metadata.json
+++ b/lib/samples/cut_geometry/README.metadata.json
@@ -20,7 +20,7 @@
         "Polyline"
     ],
     "snippets": [
-        "cut_geometry_sample.dart"
+        "cut_geometry.dart"
     ],
     "title": "Cut geometry"
 }


### PR DESCRIPTION
Cherry picks a correction to Cut Geometry metadata that is going into `main` with the latest Beta 2 samples.