### PR TITLE
Clear up a warning

### DIFF
--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -34,7 +34,7 @@ class Sample {
         _snippets = List<String>.from(json['snippets']),
         _title = json['title'],
         _keywords = List<String>.from(json['keywords']),
-        _sampleWidget = sampleWidgets[json['key']]!() ?? const Placeholder();
+        _sampleWidget = sampleWidgets[json['key']]!();
 
   String get title => _title;
 


### PR DESCRIPTION
After a recent change to how `sampleWidgets` is defined, a warning cropped up. This can no longer be null, so `??` no longer does anything.