### PR TITLE
Generate Offline Map Fix

### DIFF
--- a/lib/samples/generate_offline_map/generate_offline_map.dart
+++ b/lib/samples/generate_offline_map/generate_offline_map.dart
@@ -207,13 +207,12 @@ class _GenerateOfflineMapState extends State<GenerateOfflineMap>
     setState(() => _progress = 0);
 
     // Create parameters specifying the region to take offline.
-    final minScale = _mapViewController.scale;
-    final maxScale = _mapViewController.arcGISMap?.maxScale ?? minScale + 1;
+    // Provides a min scale to avoid requesting a huge download. Note maxScale defaults to 0.0.
+    const minScale = 1e4;
     final parameters =
         await _offlineMapTask.createDefaultGenerateOfflineMapParameters(
       areaOfInterest: envelope,
       minScale: minScale,
-      maxScale: maxScale,
     );
     parameters.continueOnErrors = false;
 


### PR DESCRIPTION
A small fix that hardcodes a minScale per another implementation and provides the default maxScale - so specifying the geometry, min and max scales are still met. Updated comments to emphasies this. In my testing this appears to resolve previously reported issues consistently. To me this still meets the aims of the sample and provides a more consistent result.