### PR TITLE
Include haptics doc in Snap Geometry Edits sample

### DIFF
--- a/lib/samples/snap_geometry_edits/README.md
+++ b/lib/samples/snap_geometry_edits/README.md
@@ -60,6 +60,8 @@ Snapping can be used during interactive edits that move existing vertices using 
 
 Geometry guides are enabled by default when snapping is enabled. These allow for snapping to a point coinciding with, parallel to, perpendicular to or extending an existing geometry.
 
+On supported platforms haptic feedback on `SnapState.snappedToFeature` and `SnapState.snappedToGeometryGuide` is enabled by default when snapping is enabled. Custom haptic feedback can be configured by setting `SnapSettings.isHapticFeedbackEnabled` to false and listening to `GeometryEditor.onSnapChanged` events to provide specific feedback depending on the `SnapState`.
+
 ## Tags
 
 edit, feature, geometry editor, graphics, layers, map, snapping

--- a/lib/samples/snap_geometry_edits/snap_geometry_edits.dart
+++ b/lib/samples/snap_geometry_edits/snap_geometry_edits.dart
@@ -60,7 +60,7 @@ class _SnapGeometryEditsState extends State<SnapGeometryEdits>
   var _geometryEditorIsStarted = false;
   var _geometryEditorHasSelectedElement = false;
   var _snappingEnabled = false;
-  var _geometryGuidesEnabled = true;
+  var _geometryGuidesEnabled = false;
   var _featureSnappingEnabled = true;
 
   // A flag for controlling the visibility of the editing toolbar.
@@ -207,6 +207,9 @@ class _SnapGeometryEditsState extends State<SnapGeometryEdits>
     // Enable snapping on the geometry editor.
     _geometryEditor.snapSettings.isEnabled = true;
     setState(() => _snappingEnabled = true);
+    // Enable geometry guides on the geometry editor.
+    _geometryEditor.snapSettings.isGeometryGuidesEnabled = true;
+    setState(() => _geometryGuidesEnabled = true);
     // Create a list of snap source settings for each geometry type and graphics overlay.
     for (final sourceSettings in _geometryEditor.snapSettings.sourceSettings) {
       // Enable all the source settings initially.


### PR DESCRIPTION
- Adds the additional notes on haptics to the Snap Geometry Edits sample
- Amends the initial default value of the geometry guides (the default is saying false in the doc - not sure if this changed or was just a mistake initially). Then sets geometry guides on by default, along with snapping.

As an aside, have tested the haptics from this sample and works well.