### PR TITLE
Improve API Key workflow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ void main() {
   // Supply your apiKey using the --dart-define-from-file command line argument.
   const apiKey = String.fromEnvironment('API_KEY');
   // Alternatively, replace the above line with the following and hard-code your apiKey here:
-  // const apiKey = 'your_api_key_here';
+  // const apiKey = ''; // Your API Key here.
   if (apiKey.isEmpty) {
     throw Exception('apiKey undefined');
   } else {

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -23,7 +23,7 @@ void main() {
   // Supply your apiKey using the --dart-define-from-file command line argument.
   const apiKey = String.fromEnvironment('API_KEY');
   // Alternatively, replace the above line with the following and hard-code your apiKey here:
-  // const apiKey = 'your_api_key_here';
+  // const apiKey = ''; // Your API Key here.
   if (apiKey.isEmpty) {
     throw Exception('apiKey undefined');
   } else {


### PR DESCRIPTION
Amends so that we better catch the API Key not being set to help with error messaging. Follows the way we have implemented in our example code.