### PR TITLE
Sample tidy ups

### DIFF
--- a/assets/generated_samples_list.json
+++ b/assets/generated_samples_list.json
@@ -34,7 +34,7 @@
     "key": "add_feature_collection_layer_from_table"
   },
   "add_feature_layer_with_time_offset": {
-    "category": "Maps",
+    "category": "Layers",
     "description": "Display a time-enabled feature layer with a time offset.",
     "ignore": false,
     "images": [
@@ -102,7 +102,7 @@
     "key": "add_feature_layers"
   },
   "add_map_image_layer": {
-    "category": "Maps",
+    "category": "Layers",
     "description": "Display a layer from an ArcGIS map image layer service.",
     "ignore": false,
     "images": [
@@ -2015,7 +2015,7 @@
     "key": "snap_geometry_edits"
   },
   "style_graphics_with_renderer": {
-    "category": "Maps",
+    "category": "Visualization",
     "description": "A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only affect graphics that do not specify their own symbol style.",
     "ignore": false,
     "images": [

--- a/lib/samples/add_feature_layer_with_time_offset/README.metadata.json
+++ b/lib/samples/add_feature_layer_with_time_offset/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps",
+    "category": "Layers",
     "description": "Display a time-enabled feature layer with a time offset.",
     "ignore": false,
     "images": [

--- a/lib/samples/add_map_image_layer/README.metadata.json
+++ b/lib/samples/add_map_image_layer/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps",
+    "category": "Layers",
     "description": "Display a layer from an ArcGIS map image layer service.",
     "ignore": false,
     "images": [

--- a/lib/samples/add_wfs_layer/README.md
+++ b/lib/samples/add_wfs_layer/README.md
@@ -1,6 +1,6 @@
 # Add WFS layer
 
-Display a layer from a WFS service using data from URL
+Display a layer from a WFS service, requesting only features for the current extent.
 
 ![Image of add WFS layer](add_wfs_layer.png)
 

--- a/lib/samples/style_graphics_with_renderer/README.md
+++ b/lib/samples/style_graphics_with_renderer/README.md
@@ -2,7 +2,7 @@
 
 A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only affect graphics that do not specify their own symbol style.
 
-![Image of style graphics with renderer](style_graphics_with_renderer.dart)
+![Image of style graphics with renderer](style_graphics_with_renderer.png)
 
 ## Use case
 

--- a/lib/samples/style_graphics_with_renderer/README.metadata.json
+++ b/lib/samples/style_graphics_with_renderer/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Maps",
+    "category": "Visualization",
     "description": "A renderer allows you to change the style of all graphics in a graphics overlay by referencing a single symbol style. A renderer will only affect graphics that do not specify their own symbol style.",
     "ignore": false,
     "images": [


### PR DESCRIPTION
After reviewing the samples directory on the developers site (where the metadata pulls through), I identified the following tidy ups:
- Some alterations to categories (they weren't specified clearly in the design repo)
- A fix to a broken image
- Correction to a partial description to match the design.