### PR TITLE
Disable tapping while an identify operation is in progress

### DIFF
--- a/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
+++ b/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
@@ -121,6 +121,9 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
   }
 
   void onTap(Offset localPosition) async {
+    // Prevent addtional taps until the identify operation is complete.
+    setState(() => _ready = false);
+
     // When the map view is tapped, perform an identify operation on the WMS layer.
     final identifyLayerResult = await _mapViewController.identifyLayer(
       _wmsLayer,
@@ -148,6 +151,9 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
         showResultsDialog();
       }
     }
+
+    // Allow additional taps.
+    setState(() => _ready = true);
   }
 
   void showResultsDialog() {


### PR DESCRIPTION
It is possible to tap twice and get two "identify" operations happening at the same time. The first one will present the info dialog properly, but the second will present a blank info dialog.

Here we flip `_ready` back to `false` during an identify to prevent extra taps.