### PR TITLE
We still need customWhiteStyle

### DIFF
--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -56,4 +56,6 @@ extension CustomTextTheme on TextTheme {
       );
 
   TextStyle get customErrorStyle => const TextStyle(color: Colors.red);
+
+  TextStyle get customWhiteStyle => const TextStyle(color: Colors.white);
 }


### PR DESCRIPTION
The recent work on ThemeData should have kept `customWhiteStyle`. This resolves the build failure.