### PR TITLE
Update "Apply symbology to Shapefile" sample's readme

### DIFF
--- a/lib/samples/apply_symbology_to_shapefile/README.md
+++ b/lib/samples/apply_symbology_to_shapefile/README.md
@@ -10,7 +10,7 @@ Feature layers created from shapefiles do not possess any rendering information,
 
 ## How to use the sample
 
-Tap the button to apply a new symbology renderer to the feature layer created from the shapefile.
+Toggle the switch to apply a new symbology renderer to the feature layer created from the shapefile.
 
 ## How it works
 


### PR DESCRIPTION
Toggle the switch to apply a new symbology renderer to the feature layer created from the shapefile.