### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/arcgis-maps-sdk-for-flutter-samples-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/arcgis-maps-sdk-for-flutter-samples-issue-template.md
@@ -1,0 +1,37 @@
+---
+name: ArcGIS Maps SDK for Flutter Samples Issue Template
+about: Reporting an issue with the ArcGIS Maps SDK for Flutter Samples.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Is your issue with one of our samples? If so, please fill out the template below. If your issue is with the SDK more generally, a new feature request, or something from your own application, please reach out via our community forum: https://community.esri.com/t5/flutter-maps-sdk-questions/bd-p/flutter-maps-sdk-questions, or through your account manager at Esri -->
+
+#### Sample
+
+Which sample are you reporting an issue with?
+e.g. Display Map
+
+#### Summary of issue
+
+-
+
+#### Error messages or warnings
+
+-
+
+#### Additional information
+
+What dev environment are you trying to run the samples on:
+- [ ] macOS
+- [ ] Windows
+
+What platform(s) are you trying to run the samples on:
+- [ ] iOS
+- [ ] Android
+
+- [ ] Have you run the setup commands from the readme?
+
+- [ ] Have you set an API key?

--- a/.github/ISSUE_TEMPLATE/arcgis-maps-sdk-for-flutter-samples-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/arcgis-maps-sdk-for-flutter-samples-issue-template.md
@@ -1,6 +1,6 @@
 ---
-name: ArcGIS Maps SDK for Flutter Samples Issue Template
-about: Reporting an issue with the ArcGIS Maps SDK for Flutter Samples.
+name: I have a problem with ArcGIS Maps SDK for Flutter Samples
+about: Report an issue with our samples. Please report issues or feature requests for the SDK more generally to our Community Forum: https://community.esri.com/t5/flutter-maps-sdk-questions/bd-p/flutter-maps-sdk-questions
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
Adds an issue template to help define this repo as being for samples related issues so that SDK related issues or feature requests are driven to the Community Forum, or individual account managers. Also communicates the URL of the forum.

In addition, asks some initial questions that will help with any issues with the samples that do arise.