### PR TITLE
Update the latest samples for the new location of util classes

### DIFF
--- a/lib/samples/add_raster_from_file/add_raster_from_file.dart
+++ b/lib/samples/add_raster_from_file/add_raster_from_file.dart
@@ -17,8 +17,6 @@ import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/utils/sample_data.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/utils/sample_state_support.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 

--- a/lib/samples/identify_raster_cell/identify_raster_cell.dart
+++ b/lib/samples/identify_raster_cell/identify_raster_cell.dart
@@ -15,8 +15,6 @@
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/utils/sample_data.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/utils/sample_state_support.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -46,8 +44,7 @@ class _IdentifyRasterCellState extends State<IdentifyRasterCell>
       body: Stack(
         children: [
           ArcGISMapView(
-            controllerProvider: () =>
-                _mapViewController,
+            controllerProvider: () => _mapViewController,
             onMapViewReady: onMapViewReady,
             onTap: onTap,
           ),


### PR DESCRIPTION
With a recent push, certain utility classes have moved to be exported from `common/common.dart`. The samples that were in flight at the time need to be updated with the new location.