### PR TITLE
Clean up OAuth logout when dismissing a sample

### DIFF
--- a/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
+++ b/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
@@ -53,22 +53,28 @@ class _AuthenticateWithOAuthState extends State<AuthenticateWithOAuth>
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     // We do not want to handle authentication challenges outside of this sample,
     // so we remove this as the challenge handler.
     ArcGISEnvironment
         .authenticationManager.arcGISAuthenticationChallengeHandler = null;
 
-    super.dispose();
-
     // Revoke OAuth tokens and remove all credentials to log out.
-    await Future.wait(
+    Future.wait(
       ArcGISEnvironment.authenticationManager.arcGISCredentialStore
           .getCredentials()
           .whereType<OAuthUserCredential>()
           .map((credential) => credential.revokeToken()),
-    );
-    ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
+    ).catchError((error) {
+      // This sample has been disposed, so we can only report errors to the console.
+      // ignore: avoid_print
+      print('Error revoking tokens: $error');
+      return [];
+    }).whenComplete(() {
+      ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
+    });
+
+    super.dispose();
   }
 
   @override

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -48,22 +48,28 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     // We do not want to handle authentication challenges outside of this sample,
     // so we remove this as the challenge handler.
     ArcGISEnvironment
         .authenticationManager.arcGISAuthenticationChallengeHandler = null;
 
-    super.dispose();
-
     // Revoke OAuth tokens and remove all credentials to log out.
-    await Future.wait(
+    Future.wait(
       ArcGISEnvironment.authenticationManager.arcGISCredentialStore
           .getCredentials()
           .whereType<OAuthUserCredential>()
           .map((credential) => credential.revokeToken()),
-    );
-    ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
+    ).catchError((error) {
+      // This sample has been disposed, so we can only report errors to the console.
+      // ignore: avoid_print
+      print('Error revoking tokens: $error');
+      return [];
+    }).whenComplete(() {
+      ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
+    });
+
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
As part of standardizing how we use widget `dispose()`, OAuth provides the most complex case. To log out properly, you need to call `revokeToken()`, which makes a network request to revoke the token on the server. This is necessarily both asynchronous and able to throw an exception. Since we don't want to use async/await in `dispose()`, we create a Future, let it run without `await`ing on it, and use `catchError()` to keep errors from escaping as unhandled exceptions.

In a real production environment, you would probably want to build a more elaborate mechanism that isn't tied to a specific widget. But I'm thinking we don't want to build that out in individual samples. With the simplified pattern we're showing here, at least it's clear that the client code is responsible for handling errors one way or another.