### PR TITLE
Sort basemaps by name

### DIFF
--- a/lib/samples/set_basemap/set_basemap.dart
+++ b/lib/samples/set_basemap/set_basemap.dart
@@ -143,10 +143,11 @@ class _SetBasemapState extends State<SetBasemap> with SampleStateSupport {
     final portal = Portal.arcGISOnline();
     // Load basemaps from portal.
     final basemaps = await portal.developerBasemaps();
+    await Future.wait(basemaps.map((basemap) => basemap.load()));
+    basemaps.sort((a, b) => a.name.compareTo(b.name));
 
     // Load each basemap to access and display attribute data in the UI.
     for (final basemap in basemaps) {
-      await basemap.load();
       if (basemap.item != null) {
         final thumbnail = basemap.item!.thumbnail;
         if (thumbnail != null) {


### PR DESCRIPTION
Sort the basemaps by name. This ensures that they will appear in the same order on every run, which is necessary for automation.

Note that the basemaps have to be loaded before we can access the name property, so those all have to be loaded before looping through them. Using "Future.wait" also ends up being more efficient, because the network requests are all initiated in parallel, rather than loading them one at a time.