### PR TITLE
Add loading indicator for Add raster from service sample

### DIFF
--- a/lib/common/busy_indicator.dart
+++ b/lib/common/busy_indicator.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class BusyIndicator extends StatelessWidget {
+  const BusyIndicator({
+    required this.labelText,
+    required this.visible,
+    super.key,
+  });
+
+  final String labelText;
+  final bool visible;
+
+  @override
+  Widget build(BuildContext context) {
+    return Visibility(
+      visible: visible,
+      child: Center(
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          width: 110,
+          height: 90,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const SizedBox(
+                width: 30,
+                height: 30,
+                child: CircularProgressIndicator(backgroundColor: Colors.white),
+              ),
+              Text(labelText),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/busy_indicator.dart
+++ b/lib/common/busy_indicator.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 
+// This is a widget that is meant to sit atop the widget stack to indicate
+// that the system is doing something without blocking user interaction.
+// The widget consists of a [CircularProgressIndicator] and a very short [Text]
+// label.
 class BusyIndicator extends StatelessWidget {
   const BusyIndicator({
     required this.labelText,

--- a/lib/samples/add_raster_from_service/add_raster_from_service.dart
+++ b/lib/samples/add_raster_from_service/add_raster_from_service.dart
@@ -35,11 +35,14 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
   var _drawing = false;
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
+  // A subscription to listen for MapViewController draw status state changes.
+  late final StreamSubscription _drawStatusChangedSubscription;
   // A subscription to listen for layer view state changes.
   late final StreamSubscription _layerViewChangedSubscription;
 
   @override
   void dispose() {
+    _drawStatusChangedSubscription.cancel();
     _layerViewChangedSubscription.cancel();
     super.dispose();
   }
@@ -61,13 +64,14 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
   }
 
   void onMapViewReady() {
-    _mapViewController.onDrawStatusChanged.listen((status) {
-      if (status == DrawStatus.inProgress) {
-        setState(() => _drawing = true);
-      } else {
-        setState(() => _drawing = false);
-      }
-    });
+    _drawStatusChangedSubscription = _mapViewController.onDrawStatusChanged
+        .listen((status) {
+          if (status == DrawStatus.inProgress) {
+            setState(() => _drawing = true);
+          } else {
+            setState(() => _drawing = false);
+          }
+        });
 
     // Create a map with the ArcGIS DarkGrayBase basemap style and set to the map view.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISDarkGrayBase);

--- a/lib/samples/add_raster_from_service/add_raster_from_service.dart
+++ b/lib/samples/add_raster_from_service/add_raster_from_service.dart
@@ -16,6 +16,7 @@
 import 'dart:async';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/common/busy_indicator.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 
@@ -30,6 +31,8 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
     with SampleStateSupport {
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
+  // A flag indicating the map is currently drawing layers.
+  var _drawing = false;
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
   // A subscription to listen for layer view state changes.
@@ -51,12 +54,21 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
             onMapViewReady: onMapViewReady,
           ),
           LoadingIndicator(visible: !_ready),
+          BusyIndicator(labelText: 'Drawing...', visible: _drawing),
         ],
       ),
     );
   }
 
   void onMapViewReady() {
+    _mapViewController.onDrawStatusChanged.listen((status) {
+      if (status == DrawStatus.inProgress) {
+        setState(() => _drawing = true);
+      } else {
+        setState(() => _drawing = false);
+      }
+    });
+
     // Create a map with the ArcGIS DarkGrayBase basemap style and set to the map view.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISDarkGrayBase);
 


### PR DESCRIPTION
Loading a raster layer from a service can take a long time. This PR adds a "Drawing..." popup to inform the user that the map is still working on rendering the layer.

**Summary of Changes**
- A new BusyIndicator widget was created and added to the common folder
- The BusyIndicator was applied to the Add raster from service sample