### PR TITLE
Update arcgis_maps version minimum

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.7.0 <4.0.0'
 
 dependencies:
-  arcgis_maps: ^200.6.0
+  arcgis_maps: ^200.7.0
   async: ^2.12.0
   build: ^2.4.2
   build_config: ^1.1.2


### PR DESCRIPTION
Cherry picking the update of the min version to `v.next` so we're up to date post-release.