### PR TITLE
linter rule strict_top_level_inference

### DIFF
--- a/linter_rules.yaml
+++ b/linter_rules.yaml
@@ -43,11 +43,11 @@ linter:
     camel_case_extensions: true
     camel_case_types: true
     cancel_subscriptions: true
-    cascade_invocations: false # cascades can sometimes detract from readability of the tutorial
+    cascade_invocations: false # cascades can sometimes detract from readability
     cast_nullable_to_non_nullable: true
     collection_methods_unrelated_type: true
     combinators_ordering: true
-    comment_references: true
+    comment_references: false # conflict between Markdown links and comment references (both use square brackets)
     conditional_uri_does_not_exist: true
     constant_identifier_names: true
     control_flow_in_finally: true
@@ -80,7 +80,7 @@ linter:
     missing_code_block_language_in_doc_comment: true
     missing_whitespace_between_adjacent_strings: true
     no_adjacent_strings_in_list: true
-    no_default_cases: true
+    no_default_cases: false # triggers on entirely reasonable uses of default
     no_duplicate_case_values: true
     no_leading_underscores_for_library_prefixes: true
     no_leading_underscores_for_local_identifiers: true
@@ -142,6 +142,7 @@ linter:
     sort_constructors_first: true
     sort_pub_dependencies: true
     sort_unnamed_constructors_first: true
+    strict_top_level_inference: true
     test_types_in_equals: true
     throw_in_finally: true
     tighten_type_of_initializing_formals: true


### PR DESCRIPTION
Adopt new linter rule, `strict_top_level_inference`. Also, clean up some other linter rules to match our internal linter rules.