### PR TITLE
Added Lazyloading

### DIFF
--- a/lib/widgets/sample_list_view.dart
+++ b/lib/widgets/sample_list_view.dart
@@ -19,18 +19,65 @@ import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_detail_page.dart'
 import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_info_popup_menu.dart';
 import 'package:flutter/material.dart';
 
-class SampleListView extends StatelessWidget {
+class SampleListView extends StatefulWidget {
   const SampleListView({required this.samples, super.key});
 
   final List<Sample> samples;
 
   @override
+  State<SampleListView> createState() => _SampleListViewState();
+}
+
+class _SampleListViewState extends State<SampleListView> {
+  final _scrollController = ScrollController();
+  final _itemsPerPage = 20;
+  final _displayedSamples = <Sample>[];
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMoreItems();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels ==
+        _scrollController.position.maxScrollExtent) {
+      _loadMoreItems();
+    }
+  }
+
+  void _loadMoreItems() {
+    setState(() {
+      final startIndex = _currentPage * _itemsPerPage;
+      final endIndex = startIndex + _itemsPerPage;
+      if (startIndex < widget.samples.length) {
+        _displayedSamples.addAll(
+          widget.samples.sublist(
+            startIndex,
+            endIndex > widget.samples.length ? widget.samples.length : endIndex,
+          ),
+        );
+        _currentPage++;
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      controller: _scrollController,
       padding: const EdgeInsets.all(8),
-      itemCount: samples.length,
+      itemCount: _displayedSamples.length,
       itemBuilder: (context, index) {
-        final sample = samples[index];
+        final sample = _displayedSamples[index];
         return Card(
           child: ListTile(
             title: Text(sample.title),


### PR DESCRIPTION
For now our `ListView.builder` builds items on demand as they are scrolled into view. But as our sample data set grows, even the overhead of managing the list of items can be significant. 

Also this helps with our rendering issue, since only few items are loaded into our `Listview.builder` at a time.

Related to [#3248](https://devtopia.esri.com/runtime/flutter/issues/3248)