### PR TITLE
Remove api key check

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,11 +29,7 @@ void main() {
   const apiKey = String.fromEnvironment('API_KEY');
   // Alternatively, replace the above line with the following and hard-code your apiKey here:
   // const apiKey = ''; // Your API Key here.
-  if (apiKey.isEmpty) {
-    throw Exception('apiKey undefined');
-  } else {
-    ArcGISEnvironment.apiKey = apiKey;
-  }
+  ArcGISEnvironment.apiKey = apiKey;
 
   runApp(
     MaterialApp(

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -25,11 +25,7 @@ void main() {
   const apiKey = String.fromEnvironment('API_KEY');
   // Alternatively, replace the above line with the following and hard-code your apiKey here:
   // const apiKey = ''; // Your API Key here.
-  if (apiKey.isEmpty) {
-    throw Exception('apiKey undefined');
-  } else {
-    ArcGISEnvironment.apiKey = apiKey;
-  }
+  ArcGISEnvironment.apiKey = apiKey;
 
   // Supply the directory name of a sample via the --dart-define command line argument
   // e.g. --dart-define=SAMPLE=display_map


### PR DESCRIPTION
With the previous ambiguous error message now being resolved we can remove the manual check for an API key being set as the error messaging now describes that an API key is required.