### PR TITLE
cs/Using gesture detector 

### DIFF
--- a/lib/samples/match_viewpoint_of_geo_views/README.md
+++ b/lib/samples/match_viewpoint_of_geo_views/README.md
@@ -14,7 +14,7 @@ Interact with the MapView or SceneView by zooming or panning. The other MapView 
 
 ## How it works
 
-1. Wire up the `onViewpointChanged` and `onNavigationChanged` event handlers for both geo views.
+1. Wire up the `onViewpointChanged` event handlers for both geo views.
 2. In each event handler, get the current viewpoint from the geo view that is being interacted with and then set the viewpoint of the other geo view to the same value.
 3. Note: The reason for setting the viewpoints in multiple event handlers is to account for different types of interactions that can occur (ie. single click pan -vs- continuous pan, single click zoom in -vs- mouse scroll wheel zoom, etc.).
 

--- a/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
+++ b/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
@@ -85,7 +85,7 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
             _isMapViewInteraction = true;
             _isSceneViewInteraction = false;
           }),
-          onDoubleTapDown: (details) => setState(() {
+          onDoubleTapDown: (_) => setState(() {
             _isMapViewInteraction = true;
             _isSceneViewInteraction = false;
           }),
@@ -99,11 +99,11 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
       Expanded(
         child: GestureDetector(
           behavior: HitTestBehavior.translucent,
-          onDoubleTapDown: (details) => setState(() {
+          onDoubleTapDown: (_) => setState(() {
             _isMapViewInteraction = false;
             _isSceneViewInteraction = true;
           }),
-          onTapDown: (details) => setState(() {
+          onTapDown: (_) => setState(() {
             _isMapViewInteraction = false;
             _isSceneViewInteraction = true;
           }),


### PR DESCRIPTION
- Using GestureDetector to decide if one of the GeoViews needs to update the other one. It is more reliable than using the navigation point changed callback.