### PR TITLE
compile sample viewer with SDK 36

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,16 +24,16 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.esri.arcgis_maps_sdk_flutter_samples"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 36
     ndkVersion "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {


### PR DESCRIPTION
Compile the Sample Viewer with compileSdk = 36 (the latest). Also updates the JVM minimum to 11.