### PR TITLE
Replace MediaQuery.of(context)

### DIFF
--- a/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
+++ b/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
@@ -299,7 +299,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
           builder: (context, setModalState) {
             return Padding(
               padding: EdgeInsets.only(
-                bottom: MediaQuery.of(context).viewInsets.bottom,
+                bottom: MediaQuery.viewInsetsOf(context).bottom,
               ),
               child: SingleChildScrollView(
                 child: Column(

--- a/lib/samples/generate_offline_map/generate_offline_map.dart
+++ b/lib/samples/generate_offline_map/generate_offline_map.dart
@@ -109,7 +109,7 @@ class _GenerateOfflineMapState extends State<GenerateOfflineMap>
               visible: _progress != null,
               child: Center(
                 child: Container(
-                  width: MediaQuery.of(context).size.width / 2,
+                  width: MediaQuery.sizeOf(context).width / 2,
                   padding: const EdgeInsets.all(20),
                   decoration: BoxDecoration(
                     color: Colors.white,

--- a/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
+++ b/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
@@ -161,7 +161,7 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
         ),
         content: SizedBox(
           height: 150,
-          width: MediaQuery.of(context).size.width * 0.75,
+          width: MediaQuery.sizeOf(context).width * 0.75,
           // Create a web view widget and set the controller to provide the content.
           child: WebViewWidget(controller: _webViewController),
         ),

--- a/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
+++ b/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
@@ -53,7 +53,7 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
   @override
   Widget build(BuildContext context) {
     final isPortrait =
-        MediaQuery.of(context).orientation == Orientation.portrait;
+        MediaQuery.orientationOf(context) == Orientation.portrait;
 
     return Scaffold(
       body: SafeArea(
@@ -91,7 +91,7 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
           onTapDown: (_) => updateViewInteraction(true),
           onDoubleTapDown: (_) => updateViewInteraction(true),
           onLongPressDown: (_) => updateViewInteraction(true),
-          onScaleStart:(_) => updateViewInteraction(true),
+          onScaleStart: (_) => updateViewInteraction(true),
           child: ArcGISMapView(
             controllerProvider: () => _mapViewController,
             onMapViewReady: onMapViewReady,
@@ -105,7 +105,7 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
           onTapDown: (_) => updateViewInteraction(false),
           onDoubleTapDown: (_) => updateViewInteraction(false),
           onLongPressDown: (_) => updateViewInteraction(false),
-          onScaleStart:(_) => updateViewInteraction(false),
+          onScaleStart: (_) => updateViewInteraction(false),
           child: ArcGISSceneView(
             controllerProvider: () => _sceneViewController,
             onSceneViewReady: onSceneViewReady,

--- a/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
+++ b/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
@@ -639,8 +639,8 @@ class FeatureDetailsState extends State<FeatureDetails> {
                 return const Center(child: Text('Loading...'));
               }
               return SizedBox(
-                height: MediaQuery.of(context).size.height,
-                width: MediaQuery.of(context).size.width * 0.75,
+                height: MediaQuery.sizeOf(context).height,
+                width: MediaQuery.sizeOf(context).width * 0.75,
                 child: WebViewWidget(controller: _webViewController),
               );
             },

--- a/lib/samples/show_legend/show_legend.dart
+++ b/lib/samples/show_legend/show_legend.dart
@@ -70,7 +70,7 @@ class _ShowLegendState extends State<ShowLegend> with SampleStateSupport {
 
   Future<void> onMapViewReady() async {
     // Get the screen scale.
-    final screenScale = MediaQuery.of(context).devicePixelRatio;
+    final screenScale = MediaQuery.devicePixelRatioOf(context);
     // Create an image layer.
     final imageLayer = ArcGISMapImageLayer.withUri(
       Uri.parse(

--- a/lib/utils/ripple_page_route.dart
+++ b/lib/utils/ripple_page_route.dart
@@ -24,7 +24,7 @@ class RipplePageRoute extends PageRouteBuilder {
         transitionDuration: const Duration(milliseconds: 600),
         pageBuilder: (_, _, _) => child,
         transitionsBuilder: (context, animation, _, child) {
-          final screenSize = MediaQuery.of(context).size;
+          final screenSize = MediaQuery.sizeOf(context);
           final diagonal = sqrt(
             pow(screenSize.width, 2) + pow(screenSize.height, 2),
           );


### PR DESCRIPTION
`MediaQuery.of(context)` is inefficient (your widget will rebuild for every change to any property of `MediaQuery`). We should always use a more specific accessor, such as `MediaQuery.sizeOf(context)`.