### PR TITLE
Fix potential access of "late" variables

### DIFF
--- a/lib/samples/add_raster_from_service/add_raster_from_service.dart
+++ b/lib/samples/add_raster_from_service/add_raster_from_service.dart
@@ -36,14 +36,14 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
   // A subscription to listen for MapViewController draw status state changes.
-  late final StreamSubscription _drawStatusChangedSubscription;
+  StreamSubscription? _drawStatusChangedSubscription;
   // A subscription to listen for layer view state changes.
-  late final StreamSubscription _layerViewChangedSubscription;
+  StreamSubscription? _layerViewChangedSubscription;
 
   @override
   void dispose() {
-    _drawStatusChangedSubscription.cancel();
-    _layerViewChangedSubscription.cancel();
+    _drawStatusChangedSubscription?.cancel();
+    _layerViewChangedSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/samples/apply_mosaic_rule_to_rasters/apply_mosaic_rule_to_rasters.dart
+++ b/lib/samples/apply_mosaic_rule_to_rasters/apply_mosaic_rule_to_rasters.dart
@@ -63,7 +63,7 @@ class _ApplyMosaicRuleToRastersState extends State<ApplyMosaicRuleToRasters>
   var _selectedMosaicMethod = MosaicMethodEnum.objectID;
   // Raster to apply the mosaic rule.
   late ImageServiceRaster _raster;
-  late StreamSubscription<DrawStatus> _drawStatusSubscription;
+  StreamSubscription<DrawStatus>? _drawStatusSubscription;
 
   @override
   Widget build(BuildContext context) {
@@ -131,7 +131,7 @@ class _ApplyMosaicRuleToRastersState extends State<ApplyMosaicRuleToRasters>
 
   @override
   void dispose() {
-    _drawStatusSubscription.cancel();
+    _drawStatusSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
+++ b/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
@@ -38,15 +38,15 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
   // A flag to indicate if the scene view is currently interacting.
   bool _isSceneViewInteraction = false;
   // Stream subscriptions for viewpoint changes.
-  late StreamSubscription _mapViewViewpointChangedSubscription;
-  late StreamSubscription _sceneViewViewpointChangedSubscription;
+  StreamSubscription? _mapViewViewpointChangedSubscription;
+  StreamSubscription? _sceneViewViewpointChangedSubscription;
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
 
   @override
   void dispose() {
-    _mapViewViewpointChangedSubscription.cancel();
-    _sceneViewViewpointChangedSubscription.cancel();
+    _mapViewViewpointChangedSubscription?.cancel();
+    _sceneViewViewpointChangedSubscription?.cancel();
     super.dispose();
   }
 


### PR DESCRIPTION
A "late" variable that is accessed in the "dispose()" method must be created in "initState()" (or before). If it is created at some later time, such as in "onMapViewReady()", there is the possibility that "dispose()" will be called before the variable is created. That would cause an unhandled exception, crashing the app.

There are different ways to handle this, but here we change it from a "late" variable to a nullable variable, and then safely use it with the `?` operator in "dispose()".
