### PR TITLE
adopt "strict-casts" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,13 @@
 include: linter_rules.yaml
+
+analyzer:
+  errors:
+    close_sinks: warning
+    missing_required_param: error
+    missing_return: error
+    record_literal_one_positional_no_trailing_comma: error
+    collection_methods_unrelated_type: warning
+    unrelated_type_equality_checks: error
+
+  language:
+    strict-casts: true

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -23,12 +23,12 @@ import 'package:flutter/material.dart';
 /// The Widget for each sample is pulled from the samples_widget_list.dart.
 class Sample {
   Sample.fromJson(Map<String, dynamic> json)
-    : _category = json['category'],
-      _description = json['description'],
+    : _category = json['category'] as String? ?? '',
+      _description = json['description'] as String? ?? '',
       _snippets = List<String>.from(json['snippets']),
-      _title = json['title'],
+      _title = json['title'] as String? ?? '',
       _keywords = List<String>.from(json['keywords']),
-      _key = json['key'],
+      _key = json['key'] as String? ?? '',
       _sampleWidget = sampleWidgets[json['key']]!();
   final String _category;
   final String _description;

--- a/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
+++ b/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
@@ -142,7 +142,7 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
   @override
   void initState() {
     super.initState();
-    _damageType = widget.arcGISFeature.attributes['typdamage'];
+    _damageType = widget.arcGISFeature.attributes['typdamage'] as String? ?? '';
     _loadAttachments();
   }
 

--- a/lib/samples/manage_features/manage_features.dart
+++ b/lib/samples/manage_features/manage_features.dart
@@ -222,7 +222,7 @@ class _ManageFeaturesState extends State<ManageFeatures>
       _damageFeatureLayer.selectFeature(feature);
       setState(() {
         _selectedFeature = feature;
-        _selectedDamageType = feature.attributes['typdamage'];
+        _selectedDamageType = feature.attributes['typdamage'] as String?;
       });
     }
     // Re-enable the UI.

--- a/lib/samples/query_related_features/query_related_features.dart
+++ b/lib/samples/query_related_features/query_related_features.dart
@@ -251,7 +251,8 @@ class _QueryRelatedFeaturesState extends State<QueryRelatedFeatures>
         final displayFieldName = relatedTable.layerInfo!.displayFieldName;
 
         // Get the display name for the feature.
-        final featureDisplayname = relatedFeature.attributes[displayFieldName];
+        final featureDisplayname =
+            relatedFeature.attributes[displayFieldName] as String? ?? '';
 
         // Add the display name to the list.
         relatedFeatures.add(featureDisplayname);
@@ -262,7 +263,7 @@ class _QueryRelatedFeaturesState extends State<QueryRelatedFeatures>
     // Update the UI with the related features.
     setState(() {
       _loadingFeatures = false;
-      _selectedParkName = selectedPark.attributes['UNIT_NAME'];
+      _selectedParkName = selectedPark.attributes['UNIT_NAME'] as String? ?? '';
 
       _featurePreserves = relatedFeaturesLists[0];
 

--- a/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
+++ b/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
@@ -628,7 +628,7 @@ class FeatureDetailsState extends State<FeatureDetails> {
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          _feature.attributes['name'],
+          _feature.attributes['name'] as String? ?? '',
           style: Theme.of(context).textTheme.headlineMedium,
         ),
         Flexible(
@@ -655,7 +655,7 @@ class FeatureDetailsState extends State<FeatureDetails> {
       const Color.fromARGB(0, 255, 255, 255),
     );
 
-    final description = _feature.attributes['description'];
+    final description = _feature.attributes['description'] as String? ?? '';
     final attachmentUrls = await _fetchAttachmentsForFeature();
     final htmlDescription = _wrapDescriptionInHtml(description, attachmentUrls);
     await _webViewController.loadHtmlString(htmlDescription);

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -186,7 +186,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     );
     final sampleData = jsonDecode(jsonString) as Map<String, dynamic>;
     for (final s in sampleData.entries) {
-      _allSamples.add(Sample.fromJson(s.value));
+      _allSamples.add(Sample.fromJson(s.value as Map<String, dynamic>));
     }
 
     if (widget.category != null) {


### PR DESCRIPTION
Turn on the "strict-casts" language mode to require ourselves to make casts explicit rather than implicitly casting from `dynamic`. Also adopt the other "analyzer/errors" settings we use internally.

This required several adjustments where we weren't following this rule, such as when working with JSON objects.
