### PR TITLE
Update samples to use the toolkit Authenticator component

### DIFF
--- a/lib/samples/authenticate_with_oauth/README.md
+++ b/lib/samples/authenticate_with_oauth/README.md
@@ -21,7 +21,6 @@ When you run the sample, the app will load a web map which contains premium cont
 
 ## Relevant API
 
-* AuthenticationManager
 * Authenticator
 * OAuthConfiguration
 * Portal

--- a/lib/samples/authenticate_with_oauth/README.md
+++ b/lib/samples/authenticate_with_oauth/README.md
@@ -15,18 +15,15 @@ When you run the sample, the app will load a web map which contains premium cont
 
 ## How it works
 
-1. Implement the `ArcGISAuthenticationChallengeHandler` interface to handle the challenges sent by the protected map service.
-2. Set the `arcGISAuthenticationChallengeHandler` property on `AuthenticationManager`.
-3. Create an `OAuthConfiguration` specifying the portal URL, client ID, and redirect URL.
-4. Load a map with premium content from a `PortalItem` requiring authentication to automatically invoke the authentication challenge.
-5. Use the OAuth user configuration to create and apply an `OAuthUserCredential` in response to the authentication challenge.
+1. Create an `OAuthConfiguration` specifying the portal URL, client ID, and redirect URL.
+2. Create a toolkit component `Authenticator` widget with the OAuth user configuration.
+3. Load a map with premium content from a `PortalItem` requiring authentication to automatically invoke the authentication challenge.
 
 ## Relevant API
 
-* ArcGISAuthenticationChallengeHandler
 * AuthenticationManager
+* Authenticator
 * OAuthConfiguration
-* OAuthUserCredential
 * Portal
 * PortalItem
 

--- a/lib/samples/authenticate_with_oauth/README.metadata.json
+++ b/lib/samples/authenticate_with_oauth/README.metadata.json
@@ -13,19 +13,17 @@
         "credential",
         "portal",
         "security",
-        "ArcGISAuthenticationChallengeHandler",
         "AuthenticationManager",
+        "Authenticator",
         "OAuthConfiguration",
-        "OAuthUserCredential",
         "Portal",
         "PortalItem"
     ],
     "redirect_from": [],
     "relevant_apis": [
-        "ArcGISAuthenticationChallengeHandler",
         "AuthenticationManager",
+        "Authenticator",
         "OAuthConfiguration",
-        "OAuthUserCredential",
         "Portal",
         "PortalItem"
     ],

--- a/lib/samples/authenticate_with_oauth/README.metadata.json
+++ b/lib/samples/authenticate_with_oauth/README.metadata.json
@@ -13,7 +13,6 @@
         "credential",
         "portal",
         "security",
-        "AuthenticationManager",
         "Authenticator",
         "OAuthConfiguration",
         "Portal",
@@ -21,7 +20,6 @@
     ],
     "redirect_from": [],
     "relevant_apis": [
-        "AuthenticationManager",
         "Authenticator",
         "OAuthConfiguration",
         "Portal",

--- a/lib/samples/authenticate_with_token/README.md
+++ b/lib/samples/authenticate_with_token/README.md
@@ -14,19 +14,17 @@ Once you launch the app, you will be challenged for an ArcGIS Online login to vi
 
 ## How it works
 
-1. Implement the `ArcGISAuthenticationChallengeHandler` interface to handle the challenges sent by the protected map service.
-2. Set the `arcGISAuthenticationChallengeHandler` property on `AuthenticationManager`.
-3. Create a `Portal`.
-4. Create a `PortalItem` for the protected web map using the `Portal` and Item ID of the protected map service.
-5. Create a map to display in the `ArcGISMapView` using the `PortalItem`.
-6. Set the map to display in the `ArcGISMapView`.
+1. Create a toolkit component `Authenticator` widget.
+2. Create a `Portal`.
+3. Create a `PortalItem` for the protected web map using the `Portal` and Item ID of the protected map service.
+4. Create a map to display in the `ArcGISMapView` using the `PortalItem`.
+5. Set the map to display in the `ArcGISMapView`.
 
 ## Relevant API
 
-* ArcGISAuthenticationChallengeHandler
 * ArcGISMap
 * ArcGISMapView
-* AuthenticationManager
+* Authenticator
 * Portal
 * PortalItem
 

--- a/lib/samples/authenticate_with_token/README.metadata.json
+++ b/lib/samples/authenticate_with_token/README.metadata.json
@@ -11,19 +11,17 @@
         "portal",
         "remember",
         "security",
-        "ArcGISAuthenticationChallengeHandler",
         "ArcGISMap",
         "ArcGISMapView",
-        "AuthenticationManager",
+        "Authenticator",
         "Portal",
         "PortalItem"
     ],
     "redirect_from": [],
     "relevant_apis": [
-        "ArcGISAuthenticationChallengeHandler",
         "ArcGISMap",
         "ArcGISMapView",
-        "AuthenticationManager",
+        "Authenticator",
         "Portal",
         "PortalItem"
     ],

--- a/lib/samples/authenticate_with_token/authenticate_with_token.dart
+++ b/lib/samples/authenticate_with_token/authenticate_with_token.dart
@@ -16,6 +16,7 @@
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
+import 'package:arcgis_maps_toolkit/arcgis_maps_toolkit.dart';
 import 'package:flutter/material.dart';
 
 class AuthenticateWithToken extends StatefulWidget {
@@ -26,36 +27,14 @@ class AuthenticateWithToken extends StatefulWidget {
 }
 
 class _AuthenticateWithTokenState extends State<AuthenticateWithToken>
-    with SampleStateSupport
-    implements ArcGISAuthenticationChallengeHandler {
+    with SampleStateSupport {
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
 
   @override
-  void initState() {
-    super.initState();
-
-    // Set this class to the arcGISAuthenticationChallengeHandler property on the authentication manager.
-    // This class implements the ArcGISAuthenticationChallengeHandler interface,
-    // which allows it to handle authentication challenges via calls to its
-    // handleArcGISAuthenticationChallenge() method.
-    ArcGISEnvironment
-            .authenticationManager
-            .arcGISAuthenticationChallengeHandler =
-        this;
-  }
-
-  @override
   void dispose() {
-    // We do not want to handle authentication challenges outside of this sample,
-    // so we remove this as the challenge handler.
-    ArcGISEnvironment
-            .authenticationManager
-            .arcGISAuthenticationChallengeHandler =
-        null;
-
     // Log out by removing all credentials.
-    ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
+    Authenticator.clearCredentials();
 
     super.dispose();
   }
@@ -64,10 +43,13 @@ class _AuthenticateWithTokenState extends State<AuthenticateWithToken>
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      // Add a map view to the widget tree and set a controller.
-      body: ArcGISMapView(
-        controllerProvider: () => _mapViewController,
-        onMapViewReady: onMapViewReady,
+      // Add an Authenticator to handle authentication challenges.
+      body: Authenticator(
+        // Add a map view to the widget tree and set a controller.
+        child: ArcGISMapView(
+          controllerProvider: () => _mapViewController,
+          onMapViewReady: onMapViewReady,
+        ),
       ),
     );
   }
@@ -81,137 +63,5 @@ class _AuthenticateWithTokenState extends State<AuthenticateWithToken>
         itemId: 'e5039444ef3c48b8a8fdc9227f9be7c1',
       ),
     );
-  }
-
-  @override
-  Future<void> handleArcGISAuthenticationChallenge(
-    ArcGISAuthenticationChallenge challenge,
-  ) async {
-    // Show a login dialog to handle the authentication challenge.
-    await showDialog(
-      context: context,
-      builder: (context) => LoginWidget(challenge: challenge),
-    );
-  }
-}
-
-// A widget that handles an authentication challenge by prompting the user to log in.
-class LoginWidget extends StatefulWidget {
-  const LoginWidget({required this.challenge, super.key});
-  final ArcGISAuthenticationChallenge challenge;
-
-  @override
-  State<LoginWidget> createState() => _LoginWidgetState();
-}
-
-class _LoginWidgetState extends State<LoginWidget> {
-  // Controllers for the username and password text fields.
-  final _usernameController = TextEditingController();
-  final _passwordController = TextEditingController();
-  // An error message to display.
-  String? _error;
-  // The result: true if the user logged in, false if the user canceled.
-  bool? _result;
-
-  @override
-  void dispose() {
-    // If the widget was dismissed without a result, the challenge should fail.
-    if (_result == null) widget.challenge.continueAndFail();
-
-    // Text editing controllers must be disposed.
-    _usernameController.dispose();
-    _passwordController.dispose();
-
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Dialog(
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 10,
-            children: [
-              Text(
-                'Authentication Required',
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
-              // Show the server URL that is requiring authentication.
-              Text(widget.challenge.requestUri.toString()),
-              // Text fields for the username and password.
-              TextField(
-                controller: _usernameController,
-                autocorrect: false,
-                decoration: const InputDecoration(hintText: 'Username'),
-              ),
-              TextField(
-                controller: _passwordController,
-                autocorrect: false,
-                obscureText: true,
-                decoration: const InputDecoration(hintText: 'Password'),
-              ),
-              // Buttons to cancel or log in.
-              Row(
-                children: [
-                  ElevatedButton(
-                    onPressed: cancel,
-                    child: const Text('Cancel'),
-                  ),
-                  const Spacer(),
-                  ElevatedButton(onPressed: login, child: const Text('Login')),
-                ],
-              ),
-              // Display an error message if there is one.
-              Text(
-                _error ?? '',
-                style: Theme.of(context).textTheme.customErrorStyle,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Future<void> login() async {
-    setState(() => _error = null);
-
-    // Username and password are required.
-    final username = _usernameController.text;
-    if (username.isEmpty) {
-      setState(() => _error = 'Username is required.');
-      return;
-    }
-    final password = _passwordController.text;
-    if (password.isEmpty) {
-      setState(() => _error = 'Password is required.');
-      return;
-    }
-
-    try {
-      // Attempt to create a credential with the provided username and password.
-      final credential = await TokenCredential.createWithChallenge(
-        widget.challenge,
-        username: username,
-        password: password,
-      );
-      if (!mounted) return;
-
-      // If successful, continue with the credential.
-      widget.challenge.continueWithCredential(credential);
-      Navigator.of(context).pop(_result = true);
-    } on ArcGISException catch (e) {
-      // If there was an error, display the error message.
-      setState(() => _error = e.message);
-    }
-  }
-
-  void cancel() {
-    // If the user cancels, cancel the challenge and dismiss the dialog.
-    widget.challenge.cancel();
-    Navigator.of(context).pop(_result = false);
   }
 }

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
+import 'package:arcgis_maps_toolkit/arcgis_maps_toolkit.dart';
 import 'package:flutter/material.dart';
 import 'package:simple_html_css/simple_html_css.dart';
 
@@ -60,22 +61,13 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
         null;
 
     // Revoke OAuth tokens and remove all credentials to log out.
-    Future.wait(
-          ArcGISEnvironment.authenticationManager.arcGISCredentialStore
-              .getCredentials()
-              .whereType<OAuthUserCredential>()
-              .map((credential) => credential.revokeToken()),
-        )
+    Authenticator.revokeOAuthTokens()
         .catchError((error) {
           // This sample has been disposed, so we can only report errors to the console.
           // ignore: avoid_print
           print('Error revoking tokens: $error');
-          return [];
         })
-        .whenComplete(() {
-          ArcGISEnvironment.authenticationManager.arcGISCredentialStore
-              .removeAll();
-        });
+        .whenComplete(Authenticator.clearCredentials);
 
     super.dispose();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,11 @@ environment:
 
 dependencies:
   arcgis_maps: ^200.8.0
+  arcgis_maps_toolkit: ^200.8.0
   async: ^2.12.0
   build: ^2.4.2
   build_config: ^1.1.2
-  file_picker: ^9.0.0
+  file_picker: ^10.2.0
   flutter:
     sdk: flutter
   flutter_archive: ^6.0.3


### PR DESCRIPTION
The "Authenticate with OAuth" and "Authenticate with Token" samples have been updated to use the "Authenticator" toolkit component. This removes a bunch of redundant code.

The "Show Portal User Info" sample is a bit of a special case -- it doesn't use an `ArcGISMapView`. Instead, it uses the Portal API to fetch some information, and then loads it in the UI with simple text fields. Looking at the Swift SDK version of this sample, it doesn't use the Authenticator component. I think that makes sense, because this sample is more about using those lower-level API calls. So we don't use an Authenticator component here either. But, it does make sense to use Authenticator's static functions to revoke the OAuth tokens and clear the credential store.

Lastly, as this requires the Sample Viewer to add a dependency on the `arcgis_maps_toolkit` package, we also have to update the `file_picker` dependency, because `arcgis_maps_toolkit` depends on a later version of `file_picker`.