### PR TITLE
Adopt the "strict-inference" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,3 +11,4 @@ analyzer:
 
   language:
     strict-casts: true
+    strict-inference: true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,7 +66,7 @@ class _SampleViewerAppState extends State<SampleViewerApp>
         actions: [
           IconButton(
             icon: const Icon(Icons.info_outline),
-            onPressed: () => showModalBottomSheet(
+            onPressed: () => showModalBottomSheet<void>(
               context: context,
               isScrollControlled: true,
               useSafeArea: true,
@@ -171,7 +171,7 @@ class _ResponsiveCategoryGrid extends StatelessWidget {
 
   void _onCategoryClick(BuildContext context, SampleCategory category) {
     Navigator.of(context).push(
-      PageRouteBuilder(
+      PageRouteBuilder<void>(
         transitionDuration: const Duration(milliseconds: 500),
         pageBuilder: (context, animation, secondaryAnimation) =>
             SampleViewerPage(category: category),

--- a/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
+++ b/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
@@ -408,7 +408,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
 
   // Shows the mission settings in a bottom sheet.
   void _showMissionSettings() {
-    showModalBottomSheet(
+    showModalBottomSheet<void>(
       context: context,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
@@ -505,7 +505,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
 
   // Shows the camera settings in a bottom sheet.
   void _showCameraSettings() {
-    showModalBottomSheet(
+    showModalBottomSheet<void>(
       context: context,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),

--- a/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
+++ b/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
@@ -44,7 +44,7 @@ class _AuthenticateWithOAuthState extends State<AuthenticateWithOAuth>
   void dispose() {
     // Revoke OAuth tokens and remove all credentials to log out.
     Authenticator.revokeOAuthTokens()
-        .catchError((error) {
+        .catchError((Object error) {
           // This sample has been disposed, so we can only report errors to the console.
           // ignore: avoid_print
           print('Error revoking tokens: $error');

--- a/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
+++ b/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
@@ -210,7 +210,7 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
       );
     }
     if (mounted) {
-      await showDialog(
+      await showDialog<void>(
         context: context,
         barrierColor: Colors.transparent,
         builder: (context) {

--- a/lib/samples/display_clusters/display_clusters.dart
+++ b/lib/samples/display_clusters/display_clusters.dart
@@ -148,7 +148,7 @@ class _DisplayClustersState extends State<DisplayClusters>
 
   void showResultsDialog(List<GeoElement> geoElements) {
     // Create a dialog that lists the count and names of the provided list of geoelements.
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) {
         return AlertDialog(

--- a/lib/samples/download_preplanned_map_area/download_preplanned_map_area.dart
+++ b/lib/samples/download_preplanned_map_area/download_preplanned_map_area.dart
@@ -314,10 +314,10 @@ class PreplannedEntryListTile extends StatelessWidget {
   final PreplannedEntry preplannedEntry;
 
   // A callback function that is called to initiate the download job for the preplanned entry.
-  final Function() onDownload;
+  final void Function() onDownload;
 
   // A callback function that is called to select the preplanned entry.
-  final Function() onSelect;
+  final void Function() onSelect;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
+++ b/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
@@ -91,7 +92,7 @@ class _EditFeatureAttachmentsState extends State<EditFeatureAttachments>
 
   // Show the bottom sheet to display the attachment information.
   void _showBottomSheet(ArcGISFeature selectedFeature) {
-    showModalBottomSheet(
+    showModalBottomSheet<void>(
       context: context,
       builder: (context) => AttachmentsOptions(
         arcGISFeature: selectedFeature,
@@ -126,7 +127,7 @@ class AttachmentsOptions extends StatefulWidget {
     super.key,
   });
   final ArcGISFeature arcGISFeature;
-  final Function(ArcGISFeature) applyEdits;
+  final FutureOr<void> Function(ArcGISFeature) applyEdits;
 
   @override
   State<AttachmentsOptions> createState() => _AttachmentsOptionsState();
@@ -256,7 +257,7 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
 
     // Display the attachment image/pdf file in a dialog.
     if (mounted) {
-      await showDialog(
+      await showDialog<void>(
         context: context,
         builder: (context) {
           return AlertDialog(

--- a/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
+++ b/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
@@ -223,7 +223,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
   }
 
   void _showMoveConfirmationDialog(Feature feature, ArcGISPoint mapPoint) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Confirm Move'),
@@ -254,7 +254,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
   }
 
   void _editDamageType(Feature feature) {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) {
         return AlertDialog(

--- a/lib/samples/find_route/find_route.dart
+++ b/lib/samples/find_route/find_route.dart
@@ -82,7 +82,7 @@ class _FindRouteState extends State<FindRoute> with SampleStateSupport {
                       // Create a button to show the directions.
                       ElevatedButton(
                         onPressed: _routeGenerated
-                            ? () => showDialog(
+                            ? () => showDialog<void>(
                                 context: context,
                                 builder: showDirections,
                               )

--- a/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
+++ b/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
@@ -122,7 +122,7 @@ class _FindRouteInMobileMapPackageState
                       // When the card is tapped, navigate to a FindRouteInMap page.
                       onTap: () {
                         Navigator.of(context).push(
-                          MaterialPageRoute(
+                          MaterialPageRoute<void>(
                             builder: (context) =>
                                 FindRouteInMap(sampleData: data),
                           ),

--- a/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
+++ b/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
@@ -152,7 +152,7 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
 
   void showResultsDialog() {
     // Show a dialog containing a web view widget.
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: Text(

--- a/lib/samples/query_table_statistics/query_table_statistics.dart
+++ b/lib/samples/query_table_statistics/query_table_statistics.dart
@@ -190,7 +190,7 @@ class _QueryTableStatisticsState extends State<QueryTableStatistics>
     );
 
     // Prepare the statistics results for display.
-    final statistics = [];
+    final statistics = <String>[];
     final records = statisticsQueryResult.statisticRecords();
     for (final record in records) {
       record.statistics.forEach((key, value) {

--- a/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
+++ b/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
@@ -107,7 +107,7 @@ class _SetUpLocationDrivenGeotriggersState
                     ElevatedButton(
                       onPressed: _currentSections.isEmpty
                           ? null
-                          : () => showDialog(
+                          : () => showDialog<void>(
                               context: context,
                               builder: (context) => showFeatureDetails(
                                 context: context,
@@ -121,7 +121,7 @@ class _SetUpLocationDrivenGeotriggersState
                     ElevatedButton(
                       onPressed: _currentPois.isEmpty
                           ? null
-                          : () => showDialog(
+                          : () => showDialog<void>(
                               context: context,
                               builder: (context) => showFeatureDetails(
                                 context: context,

--- a/lib/samples/show_grid/show_grid.dart
+++ b/lib/samples/show_grid/show_grid.dart
@@ -263,12 +263,12 @@ class GridOptions extends StatefulWidget {
     super.key,
   });
 
-  final Function(GridType) onGridChanged;
-  final Function(GridColorType) onGridColorChanged;
-  final Function(GridColorType) onLabelColorChanged;
-  final Function(GridLabelPositionType) onLabelPositionChanged;
-  final Function(LatLongLabelFormatType) onLabelFormatChanged;
-  final Function(bool) onLabelVisibilityChanged;
+  final void Function(GridType) onGridChanged;
+  final void Function(GridColorType) onGridColorChanged;
+  final void Function(GridColorType) onLabelColorChanged;
+  final void Function(GridLabelPositionType) onLabelPositionChanged;
+  final void Function(LatLongLabelFormatType) onLabelFormatChanged;
+  final void Function(bool) onLabelVisibilityChanged;
   final MapViewGrids grids;
   final bool isSceneView;
 
@@ -323,7 +323,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     required T value,
     required String labelText,
     required List<T> items,
-    required Function(T) onChanged,
+    required void Function(T) onChanged,
   }) {
     return DropdownMenu<T>(
       width: double.infinity,

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -62,7 +62,7 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
 
     // Revoke OAuth tokens and remove all credentials to log out.
     Authenticator.revokeOAuthTokens()
-        .catchError((error) {
+        .catchError((Object error) {
           // This sample has been disposed, so we can only report errors to the console.
           // ignore: avoid_print
           print('Error revoking tokens: $error');

--- a/lib/utils/sample_skeleton.dart
+++ b/lib/utils/sample_skeleton.dart
@@ -75,7 +75,7 @@ class _SampleWidgetState extends State<SampleWidget> with SampleStateSupport {
     _mapViewController.arcGISMap = map;
 
     // Perform some long-running setup task.
-    await Future.delayed(const Duration(seconds: 10));
+    await Future<void>.delayed(const Duration(seconds: 10));
 
     // Set the ready state variable to true to enable the sample UI.
     setState(() => _ready = true);
@@ -93,7 +93,7 @@ class _SampleWidgetState extends State<SampleWidget> with SampleStateSupport {
     // Perform some task.
     // ignore: avoid_print
     print('Perform task');
-    await Future.delayed(const Duration(seconds: 5));
+    await Future<void>.delayed(const Duration(seconds: 5));
 
     setState(() => _ready = true);
   }

--- a/lib/widgets/sample_info_popup_menu.dart
+++ b/lib/widgets/sample_info_popup_menu.dart
@@ -62,14 +62,14 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
           case 'README':
             Navigator.push(
               context,
-              MaterialPageRoute(
+              MaterialPageRoute<void>(
                 builder: (context) => ReadmePage(sample: widget.sample),
               ),
             );
           case 'Code':
             Navigator.push(
               context,
-              MaterialPageRoute(
+              MaterialPageRoute<void>(
                 builder: (context) => CodeViewPage(sample: widget.sample),
               ),
             );

--- a/lib/widgets/sample_list_view.dart
+++ b/lib/widgets/sample_list_view.dart
@@ -38,7 +38,7 @@ class SampleListView extends StatelessWidget {
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
+                MaterialPageRoute<void>(
                   builder: (context) => SampleDetailPage(sample: sample),
                 ),
               );


### PR DESCRIPTION
The "strict-inference" language mode requires all inferred types to be unambiguous. This prompts us to understand the types of objects we're creating and makes our intent more explicit.
