### PR TITLE
Adopt the "strict-raw-types" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,3 +12,4 @@ analyzer:
   language:
     strict-casts: true
     strict-inference: true
+    strict-raw-types: true

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -30,7 +30,7 @@ class SampleCatalogBuilder implements Builder {
   };
 
   @override
-  Future build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     final assets = buildStep.findAssets(
       Glob('lib/samples/*/README.metadata.json'),
     );
@@ -80,7 +80,7 @@ class SampleWidgetsBuilder implements Builder {
   };
 
   @override
-  Future build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     final assets = buildStep.findAssets(
       Glob('lib/samples/*/README.metadata.json'),
     );

--- a/lib/samples/add_raster_from_service/add_raster_from_service.dart
+++ b/lib/samples/add_raster_from_service/add_raster_from_service.dart
@@ -36,9 +36,10 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
   // A subscription to listen for MapViewController draw status state changes.
-  StreamSubscription? _drawStatusChangedSubscription;
+  StreamSubscription<DrawStatus>? _drawStatusChangedSubscription;
   // A subscription to listen for layer view state changes.
-  StreamSubscription? _layerViewChangedSubscription;
+  StreamSubscription<({Layer layer, LayerViewState layerViewState})>?
+  _layerViewChangedSubscription;
 
   @override
   void dispose() {

--- a/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
+++ b/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
@@ -38,8 +38,8 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
   // A flag to indicate if the scene view is currently interacting.
   bool _isSceneViewInteraction = false;
   // Stream subscriptions for viewpoint changes.
-  StreamSubscription? _mapViewViewpointChangedSubscription;
-  StreamSubscription? _sceneViewViewpointChangedSubscription;
+  StreamSubscription<void>? _mapViewViewpointChangedSubscription;
+  StreamSubscription<void>? _sceneViewViewpointChangedSubscription;
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
 

--- a/lib/samples/set_basemap/set_basemap.dart
+++ b/lib/samples/set_basemap/set_basemap.dart
@@ -38,7 +38,7 @@ class _SetBasemapState extends State<SetBasemap> with SampleStateSupport {
   // Create a default image.
   final _defaultImage = Image.asset('assets/basemap_default.png');
   // Create a future to load basemaps.
-  late Future _loadBasemapsFuture;
+  late Future<void> _loadBasemapsFuture;
   // Create a variable to store the selected basemap.
   Basemap? _selectedBasemap;
 
@@ -132,7 +132,7 @@ class _SetBasemapState extends State<SetBasemap> with SampleStateSupport {
     _mapViewController.arcGISMap = _arcGISMap;
   }
 
-  Future loadBasemaps() async {
+  Future<void> loadBasemaps() async {
     // Create a portal to access online items.
     final portal = Portal.arcGISOnline();
     // Load basemaps from portal.

--- a/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
+++ b/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
@@ -44,7 +44,8 @@ class _SetUpLocationDrivenGeotriggersState
   final _sectionGeotriggerName = 'Section Geotrigger';
 
   // Stream subscriptions for the geotrigger event changes.
-  final _streamSubscriptions = <StreamSubscription>[];
+  final _streamSubscriptions =
+      <StreamSubscription<GeotriggerNotificationInfo>>[];
 
   // Maps to contain current section and POI features. Keys are the feature
   // name, values are the full Feature. Using LinkedHashMaps to maintain insertion order.

--- a/lib/samples/show_device_location/show_device_location.dart
+++ b/lib/samples/show_device_location/show_device_location.dart
@@ -40,11 +40,11 @@ class _ShowDeviceLocationState extends State<ShowDeviceLocation>
   final _locationDataSource = SystemLocationDataSource();
 
   // A subscription to receive status changes of the location data source.
-  StreamSubscription? _statusSubscription;
+  StreamSubscription<LocationDataSourceStatus>? _statusSubscription;
   var _status = LocationDataSourceStatus.stopped;
 
   // A subscription to receive changes to the auto-pan mode.
-  StreamSubscription? _autoPanModeSubscription;
+  StreamSubscription<LocationDisplayAutoPanMode>? _autoPanModeSubscription;
   var _autoPanMode = LocationDisplayAutoPanMode.recenter;
 
   // A flag for when the map view is ready and controls can be used.

--- a/lib/samples/show_device_location_history/show_device_location_history.dart
+++ b/lib/samples/show_device_location_history/show_device_location_history.dart
@@ -36,7 +36,7 @@ class _ShowDeviceLocationHistoryState extends State<ShowDeviceLocationHistory>
   // A location data source to simulate location updates.
   final _locationDataSource = SimulatedLocationDataSource();
   // Subscription to listen for location changes.
-  StreamSubscription? _locationSubscription;
+  StreamSubscription<ArcGISLocation>? _locationSubscription;
   // A GraphicsOverlay to display the location history polyline.
   final _locationHistoryLineOverlay = GraphicsOverlay();
   // A GraphicsOverlay to display the location history points.

--- a/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
+++ b/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
@@ -38,18 +38,18 @@ class _ShowDeviceLocationWithNmeaDataSourcesState
   final _locationDataSource = NmeaLocationDataSource();
 
   // Subscriptions to location data source events and members to keep current data.
-  StreamSubscription? _locationSubscription;
+  StreamSubscription<ArcGISLocation>? _locationSubscription;
   ArcGISLocation? _currentNmeaLocation;
-  StreamSubscription? _satelliteSubscription;
+  StreamSubscription<List<NmeaSatelliteInfo>>? _satelliteSubscription;
   var _currentSatelliteInfos = <NmeaSatelliteInfo>[];
 
   // Simulated NMEA data provider members.
   SimulatedNmeaDataSource? _nmeaDataSimulator;
-  StreamSubscription? _nmeaDataSubscription;
+  StreamSubscription<String>? _nmeaDataSubscription;
 
   // Enable or disable the Recenter button.
   var _enableRecenter = false;
-  StreamSubscription? _autopanSubscription;
+  StreamSubscription<LocationDisplayAutoPanMode>? _autopanSubscription;
 
   // A flag for when the NmeaLocationDataSource is running.
   var _locationDataSourceRunning = false;

--- a/lib/samples/show_grid/show_grid.dart
+++ b/lib/samples/show_grid/show_grid.dart
@@ -319,7 +319,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
   }
 
   // Create a DropdownMenu widget.
-  static DropdownMenu _createDropdownMenu<T>({
+  static DropdownMenu<T> _createDropdownMenu<T>({
     required T value,
     required String labelText,
     required List<T> items,
@@ -338,7 +338,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     );
   }
 
-  DropdownMenu _buildGridDropdown() {
+  DropdownMenu<GridType> _buildGridDropdown() {
     return _createDropdownMenu(
       value: gridType,
       labelText: 'Grid Type',
@@ -353,7 +353,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     );
   }
 
-  DropdownMenu _buildLatLongLabelFormatDropdown() {
+  DropdownMenu<LatLongLabelFormatType> _buildLatLongLabelFormatDropdown() {
     final formField = _createDropdownMenu(
       value: labelFormatType,
       labelText: 'Label Format',
@@ -366,7 +366,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     return formField;
   }
 
-  DropdownMenu _buildGridColorDropdown() {
+  DropdownMenu<GridColorType> _buildGridColorDropdown() {
     return _createDropdownMenu(
       value: gridColorType,
       labelText: 'Grid Color',
@@ -378,7 +378,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     );
   }
 
-  DropdownMenu _buildLabelColorDropdown() {
+  DropdownMenu<GridColorType> _buildLabelColorDropdown() {
     return _createDropdownMenu(
       value: gridLabelColorType,
       labelText: 'Label Color',
@@ -390,7 +390,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     );
   }
 
-  DropdownMenu _buildLabelPositionDropdown() {
+  DropdownMenu<GridLabelPositionType> _buildLabelPositionDropdown() {
     final unsupportedInSceneView = {
       GridLabelPositionType.bottomLeft,
       GridLabelPositionType.bottomRight,

--- a/lib/utils/ripple_page_route.dart
+++ b/lib/utils/ripple_page_route.dart
@@ -18,7 +18,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
-class RipplePageRoute extends PageRouteBuilder {
+class RipplePageRoute extends PageRouteBuilder<dynamic> {
   RipplePageRoute({required this.position, required this.child})
     : super(
         transitionDuration: const Duration(milliseconds: 600),


### PR DESCRIPTION
This "strict-raw-types" language mode disallows the use of raw generic types (i.e., using a generic type without type arguments). This requires us to specify the generic types, such as `Future` must now be `Future<dynamic>` or `Future<void>`, etc.
