### PR TITLE
Implement GoRouter for navigation

### DIFF
--- a/lib/router_config.dart
+++ b/lib/router_config.dart
@@ -1,0 +1,107 @@
+//
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:arcgis_maps_sdk_flutter_samples/models/category.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/sample_viewer_app.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/category_transition_page.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/code_view_page.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/readme_page.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/ripple_transition_page.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_detail_page.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_viewer_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+
+GoRouter routerConfig(List<Sample> allSamples) {
+  return GoRouter(
+    routes: [
+      // Main route to SampleViewerApp.
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const SampleViewerApp(),
+        routes: [
+          // Route to the SampleViewerPage in "search" mode.
+          GoRoute(
+            path: 'search',
+            pageBuilder: (context, state) {
+              final position = state.extra as Offset? ?? Offset.zero;
+
+              return RippleTransitionPage(
+                position: position,
+                child: SampleViewerPage(allSamples: allSamples),
+              );
+            },
+          ),
+          // Route to the SampleViewerPage with the given category.
+          GoRoute(
+            path: 'category/:category',
+            pageBuilder: (context, state) {
+              final categoryName = state.pathParameters['category'];
+              final category = SampleCategory.values.firstWhere(
+                (c) => c.name == categoryName,
+                orElse: () => SampleCategory.all,
+              );
+              return CategoryTransitionPage(
+                child: SampleViewerPage(
+                  allSamples: allSamples,
+                  category: category,
+                ),
+              );
+            },
+          ),
+          // Route to the given sample running live.
+          GoRoute(
+            path: 'sample/:sample/live',
+            builder: (context, state) {
+              final sampleKey = state.pathParameters['sample'];
+              final sample = allSamples
+                  .where((sample) => sample.key == sampleKey)
+                  .first;
+
+              return SampleDetailPage(sample: sample);
+            },
+          ),
+          // Route to the README page for the given sample.
+          GoRoute(
+            path: 'sample/:sample/README',
+            builder: (context, state) {
+              final sampleKey = state.pathParameters['sample'];
+              final sample = allSamples
+                  .where((sample) => sample.key == sampleKey)
+                  .first;
+
+              return ReadmePage(sample: sample);
+            },
+          ),
+          // Route to the Code page for the given sample.
+          GoRoute(
+            path: 'sample/:sample/Code',
+            builder: (context, state) {
+              final sampleKey = state.pathParameters['sample'];
+              final sample = allSamples
+                  .where((sample) => sample.key == sampleKey)
+                  .first;
+
+              return CodeViewPage(sample: sample);
+            },
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/sample_viewer_app.dart
+++ b/lib/sample_viewer_app.dart
@@ -1,0 +1,140 @@
+//
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:arcgis_maps_sdk_flutter_samples/models/category.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/about_info.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/category_card.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_viewer_page.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class SampleViewerApp extends StatefulWidget {
+  const SampleViewerApp({super.key});
+
+  @override
+  State<SampleViewerApp> createState() => _SampleViewerAppState();
+}
+
+class _SampleViewerAppState extends State<SampleViewerApp>
+    with SingleTickerProviderStateMixin {
+  static const double cardSpacing = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sample Categories'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => showModalBottomSheet<void>(
+              context: context,
+              isScrollControlled: true,
+              useSafeArea: true,
+              builder: (context) {
+                return FractionallySizedBox(
+                  heightFactor: 0.5,
+                  child: Column(
+                    children: [
+                      AppBar(
+                        automaticallyImplyLeading: false,
+                        title: const Text('About'),
+                        actions: [
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                        ],
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.vertical(
+                            top: Radius.circular(30),
+                          ),
+                        ),
+                      ),
+                      Container(
+                        padding: const EdgeInsets.all(20),
+                        child: const AboutInfo(title: applicationTitle),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(cardSpacing),
+        child: OrientationBuilder(
+          builder: (context, orientation) {
+            return SingleChildScrollView(
+              child: _ResponsiveCategoryGrid(orientation: orientation),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: Builder(
+        builder: (context) {
+          return FloatingActionButton(
+            onPressed: () {
+              // Get the position of the FAB.
+              final box = context.findRenderObject()! as RenderBox;
+              final position = box.localToGlobal(box.size.center(Offset.zero));
+
+              context.push('/search', extra: position);
+            },
+            child: const Icon(Icons.search),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ResponsiveCategoryGrid extends StatelessWidget {
+  const _ResponsiveCategoryGrid({required this.orientation});
+  final Orientation orientation;
+  static const double cardSpacing = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        var cardSize = (constraints.maxWidth - cardSpacing) / 2;
+        if (orientation == Orientation.landscape) {
+          cardSize = (constraints.maxHeight - cardSpacing) / 2;
+        }
+        return Wrap(
+          spacing: cardSpacing,
+          runSpacing: cardSpacing,
+          children: List.generate(
+            SampleCategory.values.length,
+            (i) => SizedBox(
+              height: cardSize,
+              width: cardSize,
+              child: CategoryCard(
+                category: SampleCategory.values[i],
+                onClick: () =>
+                    context.push('/category/${SampleCategory.values[i].name}'),
+                index: i,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/category_transition_page.dart
+++ b/lib/widgets/category_transition_page.dart
@@ -1,0 +1,35 @@
+//
+// Copyright 2025 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Custom transition page for category navigation (scale + fade + curve).
+class CategoryTransitionPage extends CustomTransitionPage<void> {
+  CategoryTransitionPage({required super.child})
+    : super(
+        transitionsBuilder: (context, animation, _, child) {
+          final curved = CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOutBack,
+          );
+          return ScaleTransition(
+            scale: Tween<double>(begin: 0.6, end: 1).animate(curved),
+            child: FadeTransition(opacity: animation, child: child),
+          );
+        },
+      );
+}

--- a/lib/widgets/code_view_page.dart
+++ b/lib/widgets/code_view_page.dart
@@ -15,6 +15,7 @@
 //
 
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_info_popup_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_syntax_view/flutter_syntax_view.dart';
 import 'package:http/http.dart' as http;
@@ -37,7 +38,13 @@ class _CodeViewPageState extends State<CodeViewPage> {
     final fileName = filePath.split('/').last;
 
     return Scaffold(
-      appBar: AppBar(title: Text(widget.sample.title)),
+      appBar: AppBar(
+        title: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(widget.sample.title),
+        ),
+        actions: [SampleInfoPopupMenu(sample: widget.sample)],
+      ),
       body: SafeArea(
         top: false,
         left: false,

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -15,6 +15,7 @@
 //
 
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_info_popup_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:markdown/markdown.dart' as md;
@@ -112,7 +113,13 @@ class _ReadmePageState extends State<ReadmePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(widget.sample.title)),
+      appBar: AppBar(
+        title: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(widget.sample.title),
+        ),
+        actions: [SampleInfoPopupMenu(sample: widget.sample)],
+      ),
       body: Column(
         children: [
           Container(

--- a/lib/widgets/ripple_transition_page.dart
+++ b/lib/widgets/ripple_transition_page.dart
@@ -15,14 +15,14 @@
 //
 
 import 'dart:math';
-
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
-class RipplePageRoute extends PageRouteBuilder<dynamic> {
-  RipplePageRoute({required this.position, required this.child})
+/// Custom transition page to ripple out from a given screen offset.
+class RippleTransitionPage extends CustomTransitionPage<void> {
+  RippleTransitionPage({required this.position, required super.child})
     : super(
         transitionDuration: const Duration(milliseconds: 600),
-        pageBuilder: (_, _, _) => child,
         transitionsBuilder: (context, animation, _, child) {
           final screenSize = MediaQuery.sizeOf(context);
           final diagonal = sqrt(
@@ -54,8 +54,8 @@ class RipplePageRoute extends PageRouteBuilder<dynamic> {
           );
         },
       );
+
   final Offset position;
-  final Widget child;
 }
 
 class _RippleClipper extends CustomClipper<Path> {

--- a/lib/widgets/sample_list_view.dart
+++ b/lib/widgets/sample_list_view.dart
@@ -15,9 +15,9 @@
 //
 
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_detail_page.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_info_popup_menu.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class SampleListView extends StatelessWidget {
   const SampleListView({required this.samples, super.key});
@@ -35,14 +35,7 @@ class SampleListView extends StatelessWidget {
           child: ListTile(
             title: Text(sample.title),
             subtitle: Text(sample.description),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute<void>(
-                  builder: (context) => SampleDetailPage(sample: sample),
-                ),
-              );
-            },
+            onTap: () => context.push('/sample/${sample.key}/live'),
             contentPadding: const EdgeInsets.only(left: 20),
             trailing: SampleInfoPopupMenu(sample: sample),
           ),

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -27,8 +27,14 @@ const applicationTitle = 'ArcGIS Maps SDK for Flutter Samples';
 
 /// A page that displays a list of sample categories.
 class SampleViewerPage extends StatefulWidget {
-  const SampleViewerPage({super.key, this.category, this.isSearchable = true});
+  const SampleViewerPage({
+    required this.allSamples,
+    this.category,
+    this.isSearchable = true,
+    super.key,
+  });
 
+  final List<Sample> allSamples;
   final SampleCategory? category;
   final bool isSearchable;
 
@@ -37,7 +43,6 @@ class SampleViewerPage extends StatefulWidget {
 }
 
 class _SampleViewerPageState extends State<SampleViewerPage> {
-  final _allSamples = <Sample>[];
   final _searchFocusNode = FocusNode();
   final _textEditingController = TextEditingController();
   var _filteredSamples = <Sample>[];
@@ -186,7 +191,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     );
     final sampleData = jsonDecode(jsonString) as Map<String, dynamic>;
     for (final s in sampleData.entries) {
-      _allSamples.add(Sample.fromJson(s.value as Map<String, dynamic>));
+      widget.allSamples.add(Sample.fromJson(s.value as Map<String, dynamic>));
     }
 
     if (widget.category != null) {
@@ -205,13 +210,13 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
       if (widget.category == null) {
         results = [];
       } else if (widget.category == SampleCategory.all) {
-        results = _allSamples;
+        results = widget.allSamples;
       } else {
         results = getSamplesByCategory(widget.category);
       }
     } else {
       if (widget.category == null || widget.category == SampleCategory.all) {
-        results = _allSamples.where((sample) {
+        results = widget.allSamples.where((sample) {
           final lowerSearchText = searchText.toLowerCase();
           return sample.title.toLowerCase().contains(lowerSearchText) ||
               sample.category.toLowerCase().contains(lowerSearchText) ||
@@ -238,10 +243,10 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
       return [];
     }
     if (category.title == SampleCategory.all.title) {
-      return _allSamples;
+      return widget.allSamples;
     }
 
-    return _allSamples.where((sample) {
+    return widget.allSamples.where((sample) {
       return sample.category.toLowerCase() == category.title.toLowerCase();
     }).toList();
   }
@@ -250,7 +255,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     final uniqueHints = <String>{};
     final random = Random();
 
-    for (final sample in _allSamples) {
+    for (final sample in widget.allSamples) {
       final title = sample.title;
 
       // Generate a hint from title (if short).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_syntax_view: ^4.1.7
   flutter_tts: ^4.2.2
   glob: ^2.1.3
+  go_router: ^16.1.0
   http: ^1.3.0
   intl: ^0.20.2
   markdown: ^7.3.0


### PR DESCRIPTION
- Moved the main `SampleViewerApp` widget out to its own file
- Factored out the `allSamples` list from `SampleViewerApp` so that it can be used by the GoRouter configuration
- Implemented a GoRouter configuration in `router_config.dart`
- Replaced the existing `Navigator` calls with GoRouter calls
- Restructured the two custom page transition animations to work with GoRouter and put into their own files
- Added the README/Code/Website menu (`SampleInfoPopupMenu`) to the README and Code pages
- Adjusted `SampleInfoPopupMenu` to use GoRouter with some special logic to make sure we're not pushing multiple instances of the README and Code pages onto the navigation stack