### PR TITLE
Fix overflow in "Animate 3D graphic"

### DIFF
--- a/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
+++ b/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
@@ -146,13 +146,13 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
                   child: Container(
                     margin: const EdgeInsets.all(16),
                     width: 170,
-                    height: 120,
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       color: Colors.black.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: Column(
+                      mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         _buildTelemetryRow('Altitude', _altitude),


### PR DESCRIPTION
This fixed height value causes an overflow on a stock Pixel 6. So instead we let the Column determine the correct size by using `MainAxisSize.min`. This will calculate the appropriate size based on whatever font metrics, which fixes this overflow, as well as provides the exact right padding. 