### PR TITLE
Only load sample data once

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,14 +30,14 @@ void main() async {
   // const apiKey = ''; // Your API Key here.
   ArcGISEnvironment.apiKey = apiKey;
 
-  final allSamples = <Sample>[];
   final jsonString = await rootBundle.loadString(
     'assets/generated_samples_list.json',
   );
   final sampleData = jsonDecode(jsonString) as Map<String, dynamic>;
-  for (final s in sampleData.entries) {
-    allSamples.add(Sample.fromJson(s.value as Map<String, dynamic>));
-  }
+
+  final allSamples = List<Sample>.unmodifiable(
+    sampleData.values.whereType<Map<String, dynamic>>().map(Sample.fromJson),
+  );
 
   final router = routerConfig(allSamples);
 

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -44,7 +44,6 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   final _searchFocusNode = FocusNode();
   final _textEditingController = TextEditingController();
   var _filteredSamples = <Sample>[];
-  var _ready = false;
   var _searchHasFocus = false;
 
   final _searchPrefixes = [
@@ -78,27 +77,27 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   @override
   void initState() {
     super.initState();
-    // Delay search after first frame.
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (mounted) {
-        await loadSamples();
-        _searchFocusNode.addListener(() {
-          if (_searchFocusNode.hasFocus != _searchHasFocus) {
-            setState(() => _searchHasFocus = _searchFocusNode.hasFocus);
-          }
-        });
 
-        _hintTimer = Timer.periodic(const Duration(seconds: 3), (_) {
-          if (!mounted) return;
+    if (widget.category != null) {
+      _filteredSamples = getSamplesByCategory(widget.category);
+    }
 
-          if (_hintMessages.isNotEmpty &&
-              !_searchHasFocus &&
-              _textEditingController.text.isEmpty) {
-            setState(() {
-              _currentHintIndex =
-                  (_currentHintIndex + 1) % _hintMessages.length;
-            });
-          }
+    generateSearchHints();
+
+    _searchFocusNode.addListener(() {
+      if (_searchFocusNode.hasFocus != _searchHasFocus) {
+        setState(() => _searchHasFocus = _searchFocusNode.hasFocus);
+      }
+    });
+
+    _hintTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (!mounted) return;
+
+      if (_hintMessages.isNotEmpty &&
+          !_searchHasFocus &&
+          _textEditingController.text.isEmpty) {
+        setState(() {
+          _currentHintIndex = (_currentHintIndex + 1) % _hintMessages.length;
         });
       }
     });
@@ -142,32 +141,29 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
               ),
             ),
           ),
-          if (_ready)
-            Expanded(
-              child: Listener(
-                onPointerDown: (_) =>
-                    FocusManager.instance.primaryFocus?.unfocus(),
-                child:
-                    _filteredSamples.isEmpty &&
-                        _textEditingController.text.isEmpty &&
-                        widget.isSearchable &&
-                        _hintMessages.isNotEmpty
-                    ? Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 12),
-                        child: AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 400),
-                          child: Text(
-                            _hintMessages[_currentHintIndex],
-                            key: ValueKey(_currentHintIndex),
-                            textAlign: TextAlign.center,
-                          ),
+          Expanded(
+            child: Listener(
+              onPointerDown: (_) =>
+                  FocusManager.instance.primaryFocus?.unfocus(),
+              child:
+                  _filteredSamples.isEmpty &&
+                      _textEditingController.text.isEmpty &&
+                      widget.isSearchable &&
+                      _hintMessages.isNotEmpty
+                  ? Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 400),
+                        child: Text(
+                          _hintMessages[_currentHintIndex],
+                          key: ValueKey(_currentHintIndex),
+                          textAlign: TextAlign.center,
                         ),
-                      )
-                    : SampleListView(samples: _filteredSamples),
-              ),
-            )
-          else
-            const Center(child: Text('Loading samples...')),
+                      ),
+                    )
+                  : SampleListView(samples: _filteredSamples),
+            ),
+          ),
         ],
       ),
     );
@@ -181,16 +177,6 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     } else {
       _searchFocusNode.requestFocus();
     }
-  }
-
-  Future<void> loadSamples() async {
-    if (widget.category != null) {
-      _filteredSamples = getSamplesByCategory(widget.category);
-    }
-
-    generateSearchHints();
-
-    setState(() => _ready = true);
   }
 
   void onSearchChanged(String searchText) {

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -186,14 +186,6 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   }
 
   Future<void> loadSamples() async {
-    final jsonString = await rootBundle.loadString(
-      'assets/generated_samples_list.json',
-    );
-    final sampleData = jsonDecode(jsonString) as Map<String, dynamic>;
-    for (final s in sampleData.entries) {
-      widget.allSamples.add(Sample.fromJson(s.value as Map<String, dynamic>));
-    }
-
     if (widget.category != null) {
       _filteredSamples = getSamplesByCategory(widget.category);
     }

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -15,13 +15,11 @@
 //
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 import 'package:arcgis_maps_sdk_flutter_samples/models/category.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_list_view.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 const applicationTitle = 'ArcGIS Maps SDK for Flutter Samples';
 


### PR DESCRIPTION
We recently changed how we loaded sample data as part of implementing GoRouter. This caused a regression where the SampleViewerPage would read the sample data again and create duplicate entries for all the samples. So here we remove the redundant loading.

We also make the sample list "unmodifiable" so that it will throw an exception if this sort of thing happens again. Plus, now that SampleViewerPage no longer has to do the asynchronous work of loading the samples, we can remove the "post frame callback" and the "_ready" state.