### PR TITLE
Open links in the external browser

### DIFF
--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/widgets/sample_info_popup_menu.d
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:markdown/markdown.dart' as md;
+import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class ReadmePage extends StatefulWidget {
@@ -39,6 +40,24 @@ class _ReadmePageState extends State<ReadmePage> {
   @override
   void initState() {
     super.initState();
+
+    _controller.setNavigationDelegate(
+      NavigationDelegate(
+        onNavigationRequest: (request) {
+          final uri = Uri.parse(request.url);
+
+          // Allow the view to load the initial 'about:blank' page.
+          if (uri.scheme == 'about') {
+            return NavigationDecision.navigate;
+          }
+
+          // Launch any other URL in the system browser (instead of this WebViewController).
+          launchUrl(uri, mode: LaunchMode.externalApplication);
+          return NavigationDecision.prevent;
+        },
+      ),
+    );
+
     _fetchMarkDown();
   }
 


### PR DESCRIPTION
Our README documents occasionally have links to other resources. We want to open these in the external system browser, where you have all the usual browsing experience (back button, etc). We make a special exception for 'about:blank', which is the URL the webview loads initially.