### PR TITLE
Upgrade to Kotlin 2.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.0'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The latest release of Flutter issues a warning that support for Kotlin 2.0.0 is being deprecated. Thus we move up to Kotlin 2.2.0.

