### PR TITLE
Upgrade to Flutter 3.35.2

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.8.1 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
 
 dependencies:
   arcgis_maps: ^300.0.0


### PR DESCRIPTION
Upgrade to Flutter 3.35.2 (and Dart 3.9.0). Flutter automatically upgrades our build configuration from iOS 12 to 13.