### PR TITLE
Add a "Snap Sources" label

### DIFF
--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
@@ -181,9 +181,19 @@ class _SnapGeometryEditsWithUtilityNetworkRulesState
     return BottomSheetSettings(
       onCloseIconPressed: () => setState(() => _settingsVisible = false),
       // A widget for each snap source to control its enabled state.
-      settingsWidgets: (context) => _snapSources
-          .map((source) => SnapSourceWidget(snapSourceItem: source))
-          .toList(),
+      settingsWidgets: (context) => [
+        Row(
+          children: [
+            Text(
+              'Snap Sources',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ],
+        ),
+        ..._snapSources.map(
+          (source) => SnapSourceWidget(snapSourceItem: source),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
Add a "Snap Sources" label to the Settings sheet for the "Snap geometry edits with utility network rules" sample.

<img width="600" height="1300" alt="Simulator Screenshot - iPhone 15 Pro Max iOS17 2 - 2025-09-12 at 11 46 26" src="https://github.com/user-attachments/assets/3f200e81-eb4b-4014-9cf6-174db272934d" />
