### PR TITLE
Adjust camelCase detection for digits

### DIFF
--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -54,7 +54,7 @@ void createNewSample(String sampleCamelName) {
 // Convert a camel case string to snake case.
 String camelToSnake(String input) {
   final snakeCase = input.replaceAllMapped(
-    RegExp('([a-z])([A-Z])'),
+    RegExp('([a-z])([0-9A-Z])'),
     (Match match) => '${match.group(1)}_${match.group(2)!.toLowerCase()}',
   );
   return snakeCase.toLowerCase();


### PR DESCRIPTION
When converting camelCase to snake_case, we were having trouble with sample names like "ShowLabelsOnLayerIn3d". The "In3d" was being treated as a single word. The fix is to allow digits to start a new word. So now we split the names between lowercase and uppercase letters, OR between a lowercase letter and a digit (0-9).