### PR TITLE
Wait until the image is loaded before swapping in the next frame

### DIFF
--- a/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
+++ b/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
@@ -271,11 +271,13 @@ class _AnimateImagesWithImageOverlayState
 
   /// Sets the image frame to the image overlay based on the index.
   void setImageFrame(int index) {
-    // Quickly release the previous image frame to avoid memory issues.
-    _imageOverlay.imageFrame = null;
-    _imageOverlay.imageFrame = ImageFrame.withImageEnvelope(
-      image: ArcGISImage.fromFile(_imageFileList[index].uri)!,
+    // Create the image frame at the specified index.
+    final imageFrame = ImageFrame.withUriEnvelope(
+      uri: _imageFileList[index].uri,
       extent: imageEnvelope,
     );
+
+    // Once the image frame is loaded, set it to the image overlay.
+    imageFrame.load().then((_) => _imageOverlay.imageFrame = imageFrame);
   }
 }


### PR DESCRIPTION
The animation on this sample was flickering. It swaps in a new "ImageFrame" object with each animation frame. An ImageFrame is "Loadable", which means it takes some fraction of a second to load before the image can be displayed. This was the source of the flicker -- while the ImageFrame was loading, it was drawn on screen empty, causing it to blink.

The fix is to trigger the load and only swap in the new ImageFrame once it has loaded. This way, there is always a loaded ImageFrame being displayed.