### PR TITLE
Refactor list tile layout in Set Basemap Sample

### DIFF
--- a/lib/samples/set_basemap/set_basemap.dart
+++ b/lib/samples/set_basemap/set_basemap.dart
@@ -69,23 +69,23 @@ class _SetBasemapState extends State<SetBasemap> with SampleStateSupport {
                       .map(
                         // Create a list tile for each basemap.
                         (basemap) => ListTile(
-                          title: Column(
-                            children: [
-                              Container(
-                                // Add a border to the selected basemap.
-                                decoration: _selectedBasemap == basemap
-                                    ? BoxDecoration(
-                                        border: Border.all(
-                                          color: Colors.blue,
-                                          width: 4,
-                                        ),
-                                      )
-                                    : null,
-                                // Display the basemap image.
-                                child: _basemaps[basemap] ?? _defaultImage,
-                              ),
-                              Text(basemap.name, textAlign: TextAlign.center),
-                            ],
+                          title: Container(
+                            // Add a border to the selected basemap.
+                            decoration: _selectedBasemap == basemap
+                                ? BoxDecoration(
+                                    border: Border.all(
+                                      color: Colors.blue,
+                                      width: 4,
+                                    ),
+                                  )
+                                : null,
+                            // Display the basemap image.
+                            child: _basemaps[basemap] ?? _defaultImage,
+                          ),
+                          // Display the basemap name.
+                          subtitle: Text(
+                            basemap.name,
+                            textAlign: TextAlign.center,
                           ),
                           // Update the map with the selected basemap.
                           onTap: () {


### PR DESCRIPTION
- Automated testing reported the names of basemaps being cut off.
- This layout moves the name to the `subtitle` property of the `ListTile` which leads to a tidier result.
- Unable to test on iOS due to reported issues building so will have to verify that separately.