### PR TITLE
Re-enable analysis samples and update constructor

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -74,12 +74,7 @@ Builder sampleWidgetsBuilder(BuilderOptions options) => SampleWidgetsBuilder();
 // Generates lib/models/samples_widget_list.dart by enumerating the samples directories
 // and creating a map of sample names to their corresponding Widgets.
 class SampleWidgetsBuilder implements Builder {
-  static const excludedSamples = {
-    //TODO(4710): re-enable Analysis samples
-    'show_line_of_sight_between_points',
-    'show_viewshed_from_geoelement_in_scene',
-    'show_viewshed_from_point_in_scene',
-  };
+  static const excludedSamples = <String>{};
 
   @override
   final buildExtensions = const {

--- a/lib/samples/show_viewshed_from_point_in_scene/show_viewshed_from_point_in_scene.dart
+++ b/lib/samples/show_viewshed_from_point_in_scene/show_viewshed_from_point_in_scene.dart
@@ -55,7 +55,7 @@ class _ShowViewshedFromPointInSceneState
 
     // Initialize the viewshed.
     _viewshed = LocationViewshed.withLocation(
-      location: ArcGISPoint(
+      ArcGISPoint(
         x: -4.50,
         y: 48.4,
         z: _height,


### PR DESCRIPTION
- Re-enabled the analysis samples. Note: had to define a type (`String`) for the `excludedSamples` to avoid analysis warning.
- Updated the constructor from a named `location` parameter to positional. 
- This was the only build error that existed.
- Verified build on iOS and Android 