### PR TITLE
Apply the "excludedSamples" list in both places

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -20,6 +20,27 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 
+const excludedSamples = <String>{};
+
+// Returns a list of metadata files, excluding the ones in the excludedSamples list.
+Future<List<String>> getMetadataFiles(BuildStep buildStep) async {
+  final assets = buildStep.findAssets(
+    Glob('lib/samples/*/README.metadata.json'),
+  );
+
+  final metadataFiles = <String>[];
+  await for (final sample in assets) {
+    final directoryName = sample.path.split('/')[2];
+    if (excludedSamples.contains(directoryName)) {
+      continue;
+    }
+
+    metadataFiles.add(sample.path);
+  }
+
+  return metadataFiles;
+}
+
 Builder sampleCatalogBuilder(BuilderOptions options) => SampleCatalogBuilder();
 
 // Generates assets/generated_samples_list.json by combining all the README.metadata.json files.
@@ -31,13 +52,7 @@ class SampleCatalogBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
-    final assets = buildStep.findAssets(
-      Glob('lib/samples/*/README.metadata.json'),
-    );
-    final metadataFiles = <String>[];
-    await for (final input in assets) {
-      metadataFiles.add(input.path);
-    }
+    final metadataFiles = await getMetadataFiles(buildStep);
     final output = AssetId(
       buildStep.inputId.package,
       'assets/generated_samples_list.json',
@@ -74,8 +89,6 @@ Builder sampleWidgetsBuilder(BuilderOptions options) => SampleWidgetsBuilder();
 // Generates lib/models/samples_widget_list.dart by enumerating the samples directories
 // and creating a map of sample names to their corresponding Widgets.
 class SampleWidgetsBuilder implements Builder {
-  static const excludedSamples = <String>{};
-
   @override
   final buildExtensions = const {
     r'$package$': ['lib/models/samples_widget_list.dart'],
@@ -83,13 +96,7 @@ class SampleWidgetsBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
-    final assets = buildStep.findAssets(
-      Glob('lib/samples/*/README.metadata.json'),
-    );
-    final samples = <String>[];
-    await for (final sample in assets) {
-      samples.add(sample.path);
-    }
+    final samples = await getMetadataFiles(buildStep);
     final output = AssetId(
       buildStep.inputId.package,
       'lib/models/samples_widget_list.dart',
@@ -104,8 +111,6 @@ class SampleWidgetsBuilder implements Builder {
             .map((filepath) => File(filepath).parent.path.split('/').last)
             .toList()
           ..sort();
-
-    sortedSampleNames.removeWhere(excludedSamples.contains);
 
     for (final sampleName in sortedSampleNames) {
       buffer.writeln(


### PR DESCRIPTION
We use `build_runner` to generate two lists of samples: `lib/models/samples_widget_list.dart` and `assets/generated_samples_list.json`. I had a mechanism in there to exclude particular samples, but it was getting applied to only `generated_samples_list.json`. That left the two lists out of sync, which caused an exception to be thrown at run time. This mechanism has been adjusted so that both lists go through the same code path and are filtered for the excluded samples.