### PR TITLE
Update to Flutter 3.41.3

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.10.4 <4.0.0'
+  sdk: '>=3.11.1 <4.0.0'
 
 dependencies:
   arcgis_maps: ^300.0.0


### PR DESCRIPTION
Update our minimum to Flutter 3.41.3 (which includes Dart 3.11.1). This version automatically updates AppFrameworkInfo.plist a little.