### PR TITLE
Improve sample generation workflow: create placeholder image, normalize README hero image, run README scripts + build_runner for immediate sample pickup

### DIFF
--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -69,7 +69,7 @@ Directory createNewSample(String sampleCamelName) {
   }
 
   // Create the sample directory
-  sampleDirectory.createSync(recursive: true);
+  sampleDirectory.createSync();
   print('> Sample directory created at ${sampleDirectory.path}');
 
   // Create the README.md file

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -150,7 +150,7 @@ void createNewSampleFile(
 // Creates a 1x1 transparent PNG named "sampleSnakeName.png" next to README.md.
 void create1pxPng(Directory sampleDirectory, String sampleSnakeName) {
   final ps = Platform.pathSeparator;
-  final pngFile = File('${sampleDirectory.path}${ps}$sampleSnakeName.png');
+  final pngFile = File('${sampleDirectory.path}$ps$sampleSnakeName.png');
 
   if (pngFile.existsSync()) {
     print('> PNG already exists: ${pngFile.path}');
@@ -202,21 +202,12 @@ Future<void> runReadmeScriptsBestEffort(
 
   print('> Running README scripts (best effort): dart ${args.join(' ')}');
 
-  final result = await Process.run(
-    'dart',
-    args,
-    workingDirectory: Directory.current.path,
-    runInShell: true,
-  );
+  final exitCode = await runCommand('dart', args, allowFailure: true);
 
-  if (result.stdout.toString().trim().isNotEmpty) stdout.write(result.stdout);
-  if (result.stderr.toString().trim().isNotEmpty) stderr.write(result.stderr);
-
-  if (result.exitCode != 0) {
+  if (exitCode != 0) {
     print(
-      '⚠️ README scripts reported issues (exit ${result.exitCode}). Continuing so the sample is runnable.',
+      '⚠️ README scripts reported issues (exit $exitCode). Continuing so the sample is runnable.',
     );
-
     print(
       '   Fix README/metadata style issues before PR; CI will still catch these.',
     );
@@ -225,19 +216,27 @@ Future<void> runReadmeScriptsBestEffort(
 
 // Deletes stale cache before running build_runner.
 Future<void> runBuildRunner() async {
-  final args = <String>[
+  final buildArgs = [
     'run',
     'build_runner',
     'build',
     '--delete-conflicting-outputs',
   ];
-  print('> Running build_runner: dart ${args.join(' ')}');
-  await runCommand('dart', ['run', 'build_runner', 'clean']);
-  await runCommand('dart', args);
+  final cleanArgs = ['run', 'build_runner', 'clean'];
+
+  print('> Running build_runner: dart ${cleanArgs.join(' ')}');
+  await runCommand('dart', cleanArgs);
+
+  print('> Running build_runner: dart ${buildArgs.join(' ')}');
+  await runCommand('dart', buildArgs);
 }
 
 // Run Command with stdout/stderr streaming and `ProcessException` on non-zero exit code for clearer failures.
-Future<void> runCommand(String executable, List<String> args) async {
+Future<int> runCommand(
+  String executable,
+  List<String> args, {
+  bool allowFailure = false,
+}) async {
   final result = await Process.run(
     executable,
     args,
@@ -245,14 +244,10 @@ Future<void> runCommand(String executable, List<String> args) async {
     runInShell: true,
   );
 
-  if (result.stdout != null && result.stdout.toString().trim().isNotEmpty) {
-    stdout.write(result.stdout);
-  }
-  if (result.stderr != null && result.stderr.toString().trim().isNotEmpty) {
-    stderr.write(result.stderr);
-  }
+  if (result.stdout.toString().trim().isNotEmpty) stdout.write(result.stdout);
+  if (result.stderr.toString().trim().isNotEmpty) stderr.write(result.stderr);
 
-  if (result.exitCode != 0) {
+  if (!allowFailure && result.exitCode != 0) {
     throw ProcessException(
       executable,
       args,
@@ -260,6 +255,8 @@ Future<void> runCommand(String executable, List<String> args) async {
       result.exitCode,
     );
   }
+
+  return result.exitCode;
 }
 
 final copyright =

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 /// Run from arcgis-maps-sdk-flutter-samples root directory.
 ///
 /// Example:
-/// dart run tool/generate_new_sample.dart AddDynamicEntityLayer "Maps"
+/// dart run tool/generate_new_sample.dart [optional SampleClassName] [optional Category]
 Future<void> main(List<String> arguments) async {
   var sampleCamelName = 'MyNewSample';
   var category = 'Maps';

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -21,7 +21,7 @@ Future<void> main(List<String> arguments) async {
 
   final sampleSnakeName = camelToSnake(sampleCamelName);
 
-  // 1) Create sample folder + template files (existing behavior)
+  // 1) Create sample folder + template files
   final sampleDirectory = createNewSample(sampleCamelName);
 
   // 2) Create a 1px placeholder png with snake_case name
@@ -41,9 +41,14 @@ Future<void> main(List<String> arguments) async {
   print('  --dart-define=SAMPLE=$sampleSnakeName');
 }
 
-/// Create a new sample directory and a sample template.
-///
-/// Returns the created sample directory.
+// Create a new sample directory and a sample template.
+//
+// The sample directory will be created in the lib/samples directory.
+// The [sampleCamelName] is expected to be in the camel case format:
+// e.g. MyNewSample
+//
+// The sample directory will be created in the format:
+// e.g. my_new_sample
 Directory createNewSample(String sampleCamelName) {
   final ps = Platform.pathSeparator;
   final currentDirectory = Directory.current;
@@ -76,7 +81,7 @@ Directory createNewSample(String sampleCamelName) {
   return sampleDirectory;
 }
 
-/// Convert a camel case string to snake case.
+// Convert a camel case string to snake case.
 String camelToSnake(String input) {
   final snakeCase = input.replaceAllMapped(
     RegExp('([a-z])([0-9A-Z])'),
@@ -85,13 +90,13 @@ String camelToSnake(String input) {
   return snakeCase.toLowerCase();
 }
 
-/// Create a new sample README.md file,
-/// or copy the template README.md file
-/// from the common-samples/designs directory if it exists.
-///
-/// Expected sibling layout:
-/// - /common-samples
-/// - /arcgis-maps-sdk-flutter-samples
+// Create a new sample README.md file,
+// or copy the template README.md file
+// from the common-samples/designs directory if it exists.
+// The common-samples directory is expected to be at the same level
+// as the samples directory.
+// - /common-samples
+// - /arcgis-maps-sdk-flutter-samples
 void createEmptyReadMeOrCopy(
   Directory sampleDirectory,
   String sampleCamelName,
@@ -111,7 +116,7 @@ void createEmptyReadMeOrCopy(
   }
 }
 
-/// Create a new sample file.
+// Create a new sample file.
 void createNewSampleFile(
   Directory sampleDirectory,
   String sampleSnakeName,
@@ -142,7 +147,7 @@ void createNewSampleFile(
   print('> A sample file $sampleSnakeName.dart created');
 }
 
-/// Creates a 1x1 transparent PNG named "<sampleSnakeName>.png" next to README.md.
+// Creates a 1x1 transparent PNG named "sampleSnakeName.png" next to README.md.
 void create1pxPng(Directory sampleDirectory, String sampleSnakeName) {
   final ps = Platform.pathSeparator;
   final pngFile = File('${sampleDirectory.path}${ps}$sampleSnakeName.png');
@@ -159,7 +164,7 @@ void create1pxPng(Directory sampleDirectory, String sampleSnakeName) {
   print('> Placeholder PNG created: ${pngFile.path}');
 }
 
-/// Replaces occurrences of "<SampleCamelName>.png" with "<sampleSnakeName>.png" in README.md.
+// Replaces occurrences of "SampleCamelName.jpg" with "sampleSnakeName.png" in README.md.
 void updateHeroImageTarget(Directory sampleDirectory, String sampleSnakeName) {
   final ps = Platform.pathSeparator;
   final readmeFile = File('${sampleDirectory.path}${ps}README.md');
@@ -187,6 +192,7 @@ void updateHeroImageTarget(Directory sampleDirectory, String sampleSnakeName) {
   readmeFile.writeAsStringSync(updated);
 }
 
+// Run Readme scripts to generate metadata.json
 Future<void> runReadmeScriptsBestEffort(
   String sampleSnakeName,
   String category,
@@ -217,6 +223,7 @@ Future<void> runReadmeScriptsBestEffort(
   }
 }
 
+// Deletes stale cache before running build_runner.
 Future<void> runBuildRunner() async {
   final args = <String>[
     'run',
@@ -229,6 +236,7 @@ Future<void> runBuildRunner() async {
   await runCommand('dart', args);
 }
 
+// Run Command with stdout/stderr streaming and `ProcessException` on non-zero exit code for clearer failures.
 Future<void> runCommand(String executable, List<String> args) async {
   final result = await Process.run(
     executable,
@@ -262,7 +270,7 @@ final copyright =
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -1,32 +1,54 @@
 // As a command line tool, we want to use print for output
 // ignore_for_file: avoid_print
 
+import 'dart:convert';
 import 'dart:io';
 
 /// Run from arcgis-maps-sdk-flutter-samples root directory.
 ///
 /// Example:
-/// dart run tool/generate_new_sample.dart [optional SampleClassName]
-void main(List<String> arguments) async {
-  var sampleDirectoryName = 'MyNewSample';
+/// dart run tool/generate_new_sample.dart AddDynamicEntityLayer "Maps"
+Future<void> main(List<String> arguments) async {
+  var sampleCamelName = 'MyNewSample';
+  var category = 'Maps';
+
   if (arguments.isNotEmpty) {
-    sampleDirectoryName = arguments[0];
+    sampleCamelName = arguments[0];
   }
-  createNewSample(sampleDirectoryName);
+  if (arguments.length >= 2 && arguments[1].trim().isNotEmpty) {
+    category = arguments[1].trim();
+  }
+
+  final sampleSnakeName = camelToSnake(sampleCamelName);
+
+  // 1) Create sample folder + template files (existing behavior)
+  final sampleDirectory = createNewSample(sampleCamelName);
+
+  // 2) Create a 1px placeholder png with snake_case name
+  create1pxPng(sampleDirectory, sampleSnakeName);
+
+  // 3) Fix README image reference (CamelCase.png -> snake_case.png)
+  updateReadmeImageReference(sampleDirectory, sampleCamelName, sampleSnakeName);
+
+  // 4) Run README scripts (generate metadata, validate)
+  await runReadmeScriptsBestEffort(sampleSnakeName, category);
+
+  // 5) Run build_runner so sample is picked up by sample_runner / generated JSON
+  await runBuildRunner();
+
+  print('\n✅ Done.');
+  print('Next: update your VS Code [launch.json] to:');
+  print('  --dart-define=SAMPLE=$sampleSnakeName');
 }
 
-// Create a new sample directory and a sample template.
-//
-// The sample directory will be created in the lib/samples directory.
-// The [sampleCamelName] is expected to be in the camel case format:
-// e.g. MyNewSample
-//
-// The sample directory will be created in the format:
-// e.g. my_new_sample
-void createNewSample(String sampleCamelName) {
+/// Create a new sample directory and a sample template.
+///
+/// Returns the created sample directory.
+Directory createNewSample(String sampleCamelName) {
   final ps = Platform.pathSeparator;
   final currentDirectory = Directory.current;
   final sampleSnakeName = camelToSnake(sampleCamelName);
+
   final sampleRootDirectory = Directory(
     '${currentDirectory.path}${ps}lib${ps}samples',
   );
@@ -40,18 +62,21 @@ void createNewSample(String sampleCamelName) {
       sampleDirectory.path,
     );
   }
+
   // Create the sample directory
-  sampleDirectory.createSync();
-  print('>Sample directory created at ${sampleDirectory.path}');
+  sampleDirectory.createSync(recursive: true);
+  print('> Sample directory created at ${sampleDirectory.path}');
 
   // Create the README.md file
   createEmptyReadMeOrCopy(sampleDirectory, sampleCamelName);
 
   // Create the sample file
   createNewSampleFile(sampleDirectory, sampleSnakeName, sampleCamelName);
+
+  return sampleDirectory;
 }
 
-// Convert a camel case string to snake case.
+/// Convert a camel case string to snake case.
 String camelToSnake(String input) {
   final snakeCase = input.replaceAllMapped(
     RegExp('([a-z])([0-9A-Z])'),
@@ -60,13 +85,13 @@ String camelToSnake(String input) {
   return snakeCase.toLowerCase();
 }
 
-// Create a new sample README.md file,
-// or copy the template README.md file
-// from the common-samples/designs directory if it exists.
-// The common-samples directory is expected to be at the same level
-// as the samples directory.
-// - /common-samples
-// - /arcgis-maps-sdk-flutter-samples
+/// Create a new sample README.md file,
+/// or copy the template README.md file
+/// from the common-samples/designs directory if it exists.
+///
+/// Expected sibling layout:
+/// - /common-samples
+/// - /arcgis-maps-sdk-flutter-samples
 void createEmptyReadMeOrCopy(
   Directory sampleDirectory,
   String sampleCamelName,
@@ -76,16 +101,17 @@ void createEmptyReadMeOrCopy(
     '${Directory.current.parent.path}${ps}common-samples${ps}designs$ps$sampleCamelName${ps}README.md',
   );
   final sampleReadmeFile = File('${sampleDirectory.path}${ps}README.md');
+
   if (templateReadmeFile.existsSync()) {
     sampleReadmeFile.writeAsBytesSync(templateReadmeFile.readAsBytesSync());
-    print('>A README FIle was created was from a template');
+    print('> A README file was created from a template');
   } else {
-    print('>An empty README file was created');
+    print('> An empty README file was created');
     sampleReadmeFile.writeAsStringSync('README-Empty');
   }
 }
 
-// Create a new sample file
+/// Create a new sample file.
 void createNewSampleFile(
   Directory sampleDirectory,
   String sampleSnakeName,
@@ -112,7 +138,117 @@ void createNewSampleFile(
       }
     }
   }
-  print('>A sample file $sampleSnakeName.dart created');
+
+  print('> A sample file $sampleSnakeName.dart created');
+}
+
+/// Creates a 1x1 transparent PNG named "<sampleSnakeName>.png" next to README.md.
+void create1pxPng(Directory sampleDirectory, String sampleSnakeName) {
+  final ps = Platform.pathSeparator;
+  final pngFile = File('${sampleDirectory.path}${ps}$sampleSnakeName.png');
+
+  if (pngFile.existsSync()) {
+    print('> PNG already exists: ${pngFile.path}');
+    return;
+  }
+
+  // 1x1 transparent PNG
+  const base64Png =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+  pngFile.writeAsBytesSync(base64Decode(base64Png));
+  print('> Placeholder PNG created: ${pngFile.path}');
+}
+
+/// Replaces occurrences of "<SampleCamelName>.png" with "<sampleSnakeName>.png" in README.md.
+void updateReadmeImageReference(
+  Directory sampleDirectory,
+  String sampleCamelName,
+  String sampleSnakeName,
+) {
+  final ps = Platform.pathSeparator;
+  final readmeFile = File('${sampleDirectory.path}${ps}README.md');
+
+  if (!readmeFile.existsSync()) {
+    print('> README.md not found, skipping image reference update');
+    return;
+  }
+
+  final content = readmeFile.readAsStringSync();
+
+  // Common template case: "AddDynamicEntityLayer.png"
+  final camelJpg = '$sampleCamelName.jpg';
+  final snakePng = '$sampleSnakeName.png';
+
+  if (!content.contains(camelJpg)) {
+    print('> README does not reference $camelJpg (nothing to replace)');
+    return;
+  }
+
+  final updated = content.replaceAll(camelJpg, snakePng);
+  readmeFile.writeAsStringSync(updated);
+  print('> README image reference updated: $camelJpg -> $snakePng');
+}
+
+Future<void> runReadmeScriptsBestEffort(
+  String sampleSnakeName,
+  String category,
+) async {
+  const scriptPath = 'tool/readme_scripts/readme_scripts_runner.dart';
+  final args = <String>['run', scriptPath, sampleSnakeName, category];
+
+  print('> Running README scripts (best effort): dart ${args.join(' ')}');
+
+  final result = await Process.run(
+    'dart',
+    args,
+    workingDirectory: Directory.current.path,
+    runInShell: true,
+  );
+
+  if (result.stdout.toString().trim().isNotEmpty) stdout.write(result.stdout);
+  if (result.stderr.toString().trim().isNotEmpty) stderr.write(result.stderr);
+
+  if (result.exitCode != 0) {
+    print(
+      '⚠️ README scripts reported issues (exit ${result.exitCode}). Continuing so the sample is runnable.',
+    );
+
+    print(
+      '   Fix README/metadata style issues before PR; CI will still catch these.',
+    );
+  }
+}
+
+Future<void> runBuildRunner() async {
+  final args = <String>['run', 'build_runner', 'build'];
+
+  print('> Running build_runner: dart ${args.join(' ')}');
+  await runCommand('dart', args);
+}
+
+Future<void> runCommand(String executable, List<String> args) async {
+  final result = await Process.run(
+    executable,
+    args,
+    workingDirectory: Directory.current.path,
+    runInShell: true,
+  );
+
+  if (result.stdout != null && result.stdout.toString().trim().isNotEmpty) {
+    stdout.write(result.stdout);
+  }
+  if (result.stderr != null && result.stderr.toString().trim().isNotEmpty) {
+    stderr.write(result.stderr);
+  }
+
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      executable,
+      args,
+      'Command failed with exit code ${result.exitCode}',
+      result.exitCode,
+    );
+  }
 }
 
 final copyright =
@@ -123,7 +259,7 @@ final copyright =
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   https://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -28,7 +28,7 @@ Future<void> main(List<String> arguments) async {
   create1pxPng(sampleDirectory, sampleSnakeName);
 
   // 3) Fix README image reference (CamelCase.png -> snake_case.png)
-  updateReadmeImageReference(sampleDirectory, sampleCamelName, sampleSnakeName);
+  updateHeroImageTarget(sampleDirectory, sampleSnakeName);
 
   // 4) Run README scripts (generate metadata, validate)
   await runReadmeScriptsBestEffort(sampleSnakeName, category);
@@ -160,33 +160,31 @@ void create1pxPng(Directory sampleDirectory, String sampleSnakeName) {
 }
 
 /// Replaces occurrences of "<SampleCamelName>.png" with "<sampleSnakeName>.png" in README.md.
-void updateReadmeImageReference(
-  Directory sampleDirectory,
-  String sampleCamelName,
-  String sampleSnakeName,
-) {
+void updateHeroImageTarget(Directory sampleDirectory, String sampleSnakeName) {
   final ps = Platform.pathSeparator;
   final readmeFile = File('${sampleDirectory.path}${ps}README.md');
 
-  if (!readmeFile.existsSync()) {
-    print('> README.md not found, skipping image reference update');
-    return;
-  }
+  if (!readmeFile.existsSync()) return;
 
   final content = readmeFile.readAsStringSync();
 
-  // Common template case: "AddDynamicEntityLayer.png"
-  final camelJpg = '$sampleCamelName.jpg';
-  final snakePng = '$sampleSnakeName.png';
+  // Capture:
+  // 1) alt text ("Image of ...")
+  // 2) target inside (...) (e.g., display-map.png)
+  // 3) optional title part (rare, but harmless):  "some title"
+  final re = RegExp(
+    r'!\[(Image of[^\]]*)\]\(([^)"\s]+)(\s+"[^"]*")?\)',
+    caseSensitive: false,
+  );
 
-  if (!content.contains(camelJpg)) {
-    print('> README does not reference $camelJpg (nothing to replace)');
-    return;
-  }
+  final updated = content.replaceFirstMapped(re, (m) {
+    final alt = m.group(1)!; // keep
+    final title = m.group(3) ?? ''; // keep if present
+    final newTarget = '$sampleSnakeName.png';
+    return '![$alt]($newTarget$title)';
+  });
 
-  final updated = content.replaceAll(camelJpg, snakePng);
   readmeFile.writeAsStringSync(updated);
-  print('> README image reference updated: $camelJpg -> $snakePng');
 }
 
 Future<void> runReadmeScriptsBestEffort(
@@ -220,9 +218,14 @@ Future<void> runReadmeScriptsBestEffort(
 }
 
 Future<void> runBuildRunner() async {
-  final args = <String>['run', 'build_runner', 'build'];
-
+  final args = <String>[
+    'run',
+    'build_runner',
+    'build',
+    '--delete-conflicting-outputs',
+  ];
   print('> Running build_runner: dart ${args.join(' ')}');
+  await runCommand('dart', ['run', 'build_runner', 'clean']);
   await runCommand('dart', args);
 }
 


### PR DESCRIPTION
## Summary

**Now we can run our sample immediately on the simulator in two steps:**

**Step 1:** Sample Creation

```
dart run tool/generate_new_sample.dart AddDynamicEntityLayer
```

**Step2: Update `launch.json`**

Update the sample name in `launch.json`:
```
--dart-define=SAMPLE=add_dyanmic_entity_layer
```

> [!TIP]
> Technically Makes sample creation essentially a one-step workflow: after running `generate_new_sample.dart`. The sample is immediately available in the Sample Viewer, so you can just run `main.dart` right away.

# Improved sample generation workflow in detail
The new-sample generator script creates a sample in a way that tries to be “one-command → runnable in the Sample Viewer” workflow. 

## What changed

### New CLI behavior

*   Supports an optional **category** argument (defaults to `"Maps"`), e.g.   `dart run tool/generate_new_sample.dart AddDynamicEntityLayer "Scenes"` (This **category** is used for `readme_scripts_runner.dart`.

### Generates a placeholder hero image

*   Creates a **1x1 transparent PNG** named `<sample_snake_name>.png` in the sample directory to ensure an image asset exists from the start.

### Fixes the README hero image reference (properly)

*   Updates the first README image name to `snake_case.png`. 

### Runs README scripts (best effort)

*   Runs `readme_scripts_runner.dart` after generating the sample so README checks / metadata generation happen automatically.
*   If README scripts fail (e.g., `mdl`), the generator prints warnings but continues so sample creation doesn’t get blocked. 

### Ensures the sample is picked up by the viewer/catalog generation
*   Runs build\_runner with:
    *   `dart run build_runner clean` (forces a refresh of the build graph)
    *   `dart run build_runner build --delete-conflicting-outputs`
*   This is intended to update generated artifacts (catalog/list JSON + widget list) so the new sample becomes runnable immediately.

### Final Next step Hint:
*   Prints a final “Next: update launch.json…” hint with the correct `--dart-define=SAMPLE=<snake_name>` value.

