### PR TITLE
use "BackButton" to make sure it uses the system icon

### DIFF
--- a/lib/widgets/sample_detail_page.dart
+++ b/lib/widgets/sample_detail_page.dart
@@ -29,10 +29,7 @@ class SampleDetailPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: FittedBox(fit: BoxFit.scaleDown, child: Text(sample.title)),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => _handleBackNavigation(context),
-        ),
+        leading: BackButton(onPressed: () => _handleBackNavigation(context)),
         actions: [SampleInfoPopupMenu(sample: sample)],
       ),
       body: sample.getSampleWidget(),


### PR DESCRIPTION
`SampleDetailPage` is the widget that hosts each individual sample. It has a "Back" button in the `AppBar`. We were using an `IconButton` with `Icons.arrow_back`. This is slightly incorrect. On iOS at least, you want a left chevron '<', instead of a left arrow. To ensure we get the proper "back" icon, we are supposed to use a `BackButton`, which selects the proper icon for the platform.