### PR TITLE
Update share_plus for iOS 26 support

### DIFF
--- a/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
+++ b/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
@@ -137,7 +137,7 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
   Future<void> _setupGeodatabase() async {
     final directory = await getApplicationDocumentsDirectory();
     final geodatabaseFile = File(
-      '${directory.path}${Platform.pathSeparator}localHistory.geodatabase',
+      '${directory.path}${Platform.pathSeparator}LocationHistory.geodatabase',
     );
     if (geodatabaseFile.existsSync()) geodatabaseFile.deleteSync();
 
@@ -260,9 +260,8 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
     _geodatabase?.close();
 
     // Open the platform share sheet and share the mobile geodatabase file URI.
-    await Share.share(
-      subject: 'Sharing the geodatabase',
-      _geodatabase!.fileUri.path,
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(_geodatabase!.fileUri.path)]),
     );
 
     // Create a new mobile geodatabase and feature table to start again.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   package_info_plus: ^9.0.0
   path: ^1.9.1
   path_provider: ^2.1.5
-  share_plus: ^10.1.4
+  share_plus: ^12.0.2
   simple_html_css: ^5.0.0
   url_launcher: ^6.3.1
   webview_flutter: ^4.10.0


### PR DESCRIPTION
`share_plus` has a fix in its version 12 for a problem on iOS 26. It also deprecates `Share.share()` and instructs us to move to `SharePlus.instance.share()`.

Also I noticed we were using "localHistory.geodatabase" as the filename, but the design intended "LocationHistory.geodatabase".