### PR TITLE
Updated to use modelName attribute

### DIFF
--- a/lib/samples/add_building_scene_layer/add_building_scene_layer.dart
+++ b/lib/samples/add_building_scene_layer/add_building_scene_layer.dart
@@ -141,10 +141,10 @@ class _AddBuildingSceneLayerState extends State<AddBuildingSceneLayer>
 
     // Extract the overview and full model sublayers.
     _overviewSublayer = buildingSceneLayer.sublayers.firstWhere(
-      (sublayer) => sublayer.name == 'Overview',
+      (sublayer) => sublayer.modelName == 'Overview',
     );
     _fullModelSublayer = buildingSceneLayer.sublayers.firstWhere(
-      (sublayer) => sublayer.name == 'Full Model',
+      (sublayer) => sublayer.modelName == 'FullModel',
     );
 
     return buildingSceneLayer;


### PR DESCRIPTION
In building scene layers, the sublayers for "Overview" and "Full Model" have a `name` attribute and a `modelName` attribute. The `name` can have different names and languages, but the `modelName` is always "Overview" and "FullModel". As a best practice, the "Add building scene layer" sample has been updated to use `modelName`.

- Replaced `name` with `modelName` when searching for the "Overview" and "Full Model" sublayers
- "Full Model" changed to "FullModel" for modelName comparison