### PR TITLE
Apply SafeArea fixes to sample list

### DIFF
--- a/lib/widgets/sample_list_view.dart
+++ b/lib/widgets/sample_list_view.dart
@@ -28,29 +28,38 @@ class SampleListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.all(8),
-      itemCount: samples.length,
-      itemBuilder: (context, index) {
-        final sample = samples[index];
-        return Card(
-          child: ListTile(
-            title: Text(sample.title),
-            subtitle: Text(sample.description),
-            onTap: () async {
-              if (context.mounted) {
-                if (sample.hasDownloadableResources) {
-                  unawaited(context.push('/sample/${sample.key}/resources'));
-                } else {
-                  unawaited(context.push('/sample/${sample.key}/live'));
+    final padding = MediaQuery.of(context).padding.add(const EdgeInsets.all(8));
+
+    return MediaQuery.removePadding(
+      context: context,
+      removeBottom: true,
+      removeTop: true,
+      removeLeft: true,
+      removeRight: true,
+      child: ListView.builder(
+        padding: padding,
+        itemCount: samples.length,
+        itemBuilder: (context, index) {
+          final sample = samples[index];
+          return Card(
+            child: ListTile(
+              title: Text(sample.title),
+              subtitle: Text(sample.description),
+              onTap: () async {
+                if (context.mounted) {
+                  if (sample.hasDownloadableResources) {
+                    unawaited(context.push('/sample/${sample.key}/resources'));
+                  } else {
+                    unawaited(context.push('/sample/${sample.key}/live'));
+                  }
                 }
-              }
-            },
-            contentPadding: const EdgeInsets.only(left: 20),
-            trailing: SampleInfoPopupMenu(sample: sample),
-          ),
-        );
-      },
+              },
+              contentPadding: const EdgeInsets.only(left: 20),
+              trailing: SampleInfoPopupMenu(sample: sample),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -124,18 +124,22 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
         children: [
           Visibility(
             visible: widget.isSearchable,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: TextField(
-                focusNode: _searchFocusNode,
-                controller: _textEditingController,
-                onChanged: onSearchChanged,
-                autocorrect: false,
-                decoration: InputDecoration(
-                  hintText: 'Search...',
-                  suffixIcon: IconButton(
-                    icon: Icon(_searchHasFocus ? Icons.cancel : Icons.search),
-                    onPressed: onSearchSuffixPressed,
+            child: SafeArea(
+              bottom: false,
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: TextField(
+                  focusNode: _searchFocusNode,
+                  controller: _textEditingController,
+                  onChanged: onSearchChanged,
+                  autocorrect: false,
+                  decoration: InputDecoration(
+                    hintText: 'Search...',
+                    suffixIcon: IconButton(
+                      icon: Icon(_searchHasFocus ? Icons.cancel : Icons.search),
+                      onPressed: onSearchSuffixPressed,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
- The search box needed a SafeArea on the left and right when the device is rotated to landscape (it was being partially covered by system controls).
- The samples list needed some special handling along the bottom when there are system controls -- we want the ListView to extend all the way to the edge, but we want the contents of the ListView to scroll up enough to clear the system controls. This required doing some math with the MediaQuery padding for the ListView as a whole, and then removing the padding for the individual ListView items.