### PR TITLE
keep the Android system controls from overlapping our controls

### DIFF
--- a/lib/common/bottom_sheet_settings.dart
+++ b/lib/common/bottom_sheet_settings.dart
@@ -37,17 +37,8 @@ class BottomSheetSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.fromLTRB(
-        20,
-        20,
-        20,
-        max(
-          20,
-          View.of(context).viewPadding.bottom /
-              View.of(context).devicePixelRatio,
-        ),
-      ),
+    return Padding(
+      padding: bottomSheetPadding(context),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -70,4 +61,18 @@ class BottomSheetSettings extends StatelessWidget {
       ),
     );
   }
+}
+
+EdgeInsets bottomSheetPadding(BuildContext context) {
+  return EdgeInsets.fromLTRB(
+    20,
+    20,
+    20,
+    max(
+      20,
+      5 +
+          View.of(context).viewPadding.bottom /
+              View.of(context).devicePixelRatio,
+    ),
+  );
 }

--- a/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
+++ b/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
@@ -499,7 +499,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
       ),
       builder: (context) {
         return Padding(
-          padding: const EdgeInsets.all(16),
+          padding: bottomSheetPadding(context),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -602,7 +602,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
         return StatefulBuilder(
           builder: (context, setModalState) {
             return Padding(
-              padding: const EdgeInsets.all(16),
+              padding: bottomSheetPadding(context),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -694,7 +694,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
           label: value.toStringAsFixed(0),
           onChanged: onChanged,
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 4),
       ],
     );
   }

--- a/lib/samples/show_grid/show_grid.dart
+++ b/lib/samples/show_grid/show_grid.dart
@@ -304,12 +304,12 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
     return SingleChildScrollView(
       child: ListBody(
         children: [
+          _buildGridColorDropdown(),
           _buildGridDropdown(),
           if (isLabelFormatVisible)
             _buildLatLongLabelFormatDropdown()
           else
             Container(),
-          _buildGridColorDropdown(),
           _buildLabelColorDropdown(),
           _buildLabelPositionDropdown(),
           _buildLabelVisibilityCheckbox(),

--- a/lib/samples/show_grid/show_grid.dart
+++ b/lib/samples/show_grid/show_grid.dart
@@ -306,6 +306,7 @@ class _GridOptionsState extends State<GridOptions> with SampleStateSupport {
         children: [
           _buildGridColorDropdown(),
           _buildGridDropdown(),
+          const SizedBox(height: 20),
           if (isLabelFormatVisible)
             _buildLatLongLabelFormatDropdown()
           else


### PR DESCRIPTION
- "Animate 3d graphic" sample: has two bottom sheets with controls that were being overlapped by the Android system buttons. Now they re-use some logic from our `BottomSheetSettings` widget that calculates the padding while taking into consideration the system controls along the bottom, if any.
- "Show grid" sample: it has a list of several `DropdownMenu`s. There's a known Flutter issue where DropdownMenus do not take SafeArea into consideration. This causes our "Grid Color" menu to be partially obscured at the bottom. To work around that problem, I moved "Grid Color" up, where it will always have enough space below to show the whole menu. (It also makes more sense to group the grid-related settings separate from the label-related settings.)