### PR TITLE
Updated Color theme to reflect light and dark mode dynamically

### DIFF
--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -25,75 +25,118 @@ final darkColorScheme = ColorScheme.fromSeed(
   brightness: Brightness.dark,
 );
 
-// Light Theme
-final sampleViewerLightTheme = ThemeData(
-  brightness: Brightness.light,
-  colorScheme: lightColorScheme,
-  primaryColor: lightColorScheme.primary,
+// This shared builder ensures light and dark themes stay in sync,
+// differing only by their ColorScheme. Any component theme changes
+// automatically apply to both modes.
+ThemeData _buildTheme(ColorScheme colorScheme) {
+  return ThemeData(
+    brightness: colorScheme.brightness,
+    colorScheme: colorScheme,
 
-  // Application bar theme
-  appBarTheme: AppBarTheme(backgroundColor: lightColorScheme.inversePrimary),
-
-  // Text theme
-  textTheme: const TextTheme(labelMedium: TextStyle(color: Colors.deepPurple)),
-
-  // Button themes
-  elevatedButtonTheme: ElevatedButtonThemeData(
-    style: ElevatedButton.styleFrom(
-      disabledBackgroundColor: Colors.white.withValues(alpha: 0.6),
+    // Application bar theme.
+    appBarTheme: AppBarTheme(
+      backgroundColor: colorScheme.inversePrimary,
+      foregroundColor: colorScheme.onSurface,
+      elevation: 0,
+      centerTitle: false,
     ),
-  ),
 
-  floatingActionButtonTheme: FloatingActionButtonThemeData(
-    backgroundColor: lightColorScheme.primaryContainer,
-  ),
-
-  dropdownMenuTheme: DropdownMenuThemeData(
-    inputDecorationTheme: const InputDecorationTheme(
-      outlineBorder: BorderSide(width: 0),
-      border: InputBorder.none,
+    // Button themes
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+        // Use ColorScheme for disabled states (works in light & dark)
+        disabledBackgroundColor: colorScheme.onSurface.withValues(alpha: 0.12),
+        disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      ),
     ),
-    menuStyle: MenuStyle(elevation: WidgetStateProperty.all(6)),
-  ),
 
-  // Icon theme
-  iconTheme: IconThemeData(color: lightColorScheme.primary),
-);
-
-// Dark Theme
-final sampleViewerDarkTheme = ThemeData(
-  brightness: Brightness.dark,
-  colorScheme: darkColorScheme,
-  primaryColor: darkColorScheme.primary,
-
-  // Application bar theme
-  appBarTheme: AppBarTheme(backgroundColor: darkColorScheme.inversePrimary),
-
-  // Text theme - adjusted for dark mode
-  textTheme: TextTheme(labelMedium: TextStyle(color: darkColorScheme.primary)),
-
-  // Button themes
-  elevatedButtonTheme: ElevatedButtonThemeData(
-    style: ElevatedButton.styleFrom(
-      disabledBackgroundColor: Colors.black.withValues(alpha: 0.3),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(foregroundColor: colorScheme.primary),
     ),
-  ),
 
-  floatingActionButtonTheme: FloatingActionButtonThemeData(
-    backgroundColor: darkColorScheme.primaryContainer,
-  ),
-
-  dropdownMenuTheme: DropdownMenuThemeData(
-    inputDecorationTheme: const InputDecorationTheme(
-      outlineBorder: BorderSide(width: 0),
-      border: InputBorder.none,
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: colorScheme.primary,
+        side: BorderSide(color: colorScheme.outline),
+      ),
     ),
-    menuStyle: MenuStyle(elevation: WidgetStateProperty.all(6)),
-  ),
 
-  // Icon theme
-  iconTheme: IconThemeData(color: darkColorScheme.primary),
-);
+    // Floating Action Button theme.
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: colorScheme.primaryContainer,
+      foregroundColor: colorScheme.onPrimaryContainer,
+    ),
+
+    // Dropdown menu theme.
+    dropdownMenuTheme: DropdownMenuThemeData(
+      inputDecorationTheme: const InputDecorationTheme(
+        outlineBorder: BorderSide(width: 0),
+        border: InputBorder.none,
+      ),
+      menuStyle: MenuStyle(
+        elevation: WidgetStateProperty.all(6),
+        backgroundColor: WidgetStateProperty.all(colorScheme.surfaceContainer),
+      ),
+    ),
+
+    // Icon theme.
+    iconTheme: IconThemeData(color: colorScheme.primary),
+
+    // Card theme.
+    cardTheme: CardThemeData(
+      color: colorScheme.surfaceContainerLow,
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    ),
+
+    // Input Field theme.
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: colorScheme.surfaceContainerHighest,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.outline),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.outline),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.primary, width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: colorScheme.error),
+      ),
+    ),
+
+    // Divider theme.
+    dividerTheme: DividerThemeData(
+      color: colorScheme.outlineVariant,
+      thickness: 1,
+    ),
+
+    // Bottom Sheet theme.
+    bottomSheetTheme: BottomSheetThemeData(
+      backgroundColor: colorScheme.surface,
+      surfaceTintColor: colorScheme.surfaceTint,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+    ),
+  );
+}
+
+// Light theme for the sample viewer app
+final sampleViewerLightTheme = _buildTheme(lightColorScheme);
+
+// Dark theme for the sample viewer app
+final sampleViewerDarkTheme = _buildTheme(darkColorScheme);
 
 extension CustomTextTheme on TextTheme {
   TextStyle get customLabelStyle => const TextStyle(

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -1,5 +1,5 @@
 //
-// Copyright 2026 Esri
+// Copyright 2024 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -25,9 +25,7 @@ final darkColorScheme = ColorScheme.fromSeed(
   brightness: Brightness.dark,
 );
 
-// This shared builder ensures light and dark themes stay in sync,
-// differing only by their ColorScheme. Any component theme changes
-// automatically apply to both modes.
+// This shared builder ensures light and dark themes stay in sync.
 ThemeData _buildTheme(ColorScheme colorScheme) {
   return ThemeData(
     brightness: colorScheme.brightness,

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -35,7 +35,7 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
 
     // Application bar theme.
     appBarTheme: AppBarTheme(
-      backgroundColor: colorScheme.inversePrimary,
+      backgroundColor: colorScheme.surface,
       foregroundColor: colorScheme.onSurface,
       elevation: 0,
       centerTitle: false,

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -17,9 +17,7 @@
 import 'package:flutter/material.dart';
 
 // Light Theme Color Scheme
-final lightColorScheme = ColorScheme.fromSeed(
-  seedColor: Colors.deepPurple,
-);
+final lightColorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
 
 // Dark Theme Color Scheme
 final darkColorScheme = ColorScheme.fromSeed(
@@ -27,23 +25,17 @@ final darkColorScheme = ColorScheme.fromSeed(
   brightness: Brightness.dark,
 );
 
-
 // Light Theme
 final sampleViewerLightTheme = ThemeData(
-  useMaterial3: true,
   brightness: Brightness.light,
   colorScheme: lightColorScheme,
   primaryColor: lightColorScheme.primary,
 
   // Application bar theme
-  appBarTheme: AppBarTheme(
-    backgroundColor: lightColorScheme.inversePrimary,
-  ),
+  appBarTheme: AppBarTheme(backgroundColor: lightColorScheme.inversePrimary),
 
   // Text theme
-  textTheme: const TextTheme(
-    labelMedium: TextStyle(color: Colors.deepPurple),
-  ),
+  textTheme: const TextTheme(labelMedium: TextStyle(color: Colors.deepPurple)),
 
   // Button themes
   elevatedButtonTheme: ElevatedButtonThemeData(
@@ -70,20 +62,15 @@ final sampleViewerLightTheme = ThemeData(
 
 // Dark Theme
 final sampleViewerDarkTheme = ThemeData(
-  useMaterial3: true,
   brightness: Brightness.dark,
   colorScheme: darkColorScheme,
   primaryColor: darkColorScheme.primary,
 
   // Application bar theme
-  appBarTheme: AppBarTheme(
-    backgroundColor: darkColorScheme.inversePrimary,
-  ),
+  appBarTheme: AppBarTheme(backgroundColor: darkColorScheme.inversePrimary),
 
   // Text theme - adjusted for dark mode
-  textTheme: TextTheme(
-    labelMedium: TextStyle(color: darkColorScheme.primary),
-  ),
+  textTheme: TextTheme(labelMedium: TextStyle(color: darkColorScheme.primary)),
 
   // Button themes
   elevatedButtonTheme: ElevatedButtonThemeData(

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -54,17 +54,6 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
       ),
     ),
 
-    textButtonTheme: TextButtonThemeData(
-      style: TextButton.styleFrom(foregroundColor: colorScheme.primary),
-    ),
-
-    outlinedButtonTheme: OutlinedButtonThemeData(
-      style: OutlinedButton.styleFrom(
-        foregroundColor: colorScheme.primary,
-        side: BorderSide(color: colorScheme.outline),
-      ),
-    ),
-
     // Floating Action Button theme.
     floatingActionButtonTheme: FloatingActionButtonThemeData(
       backgroundColor: colorScheme.primaryContainer,
@@ -80,53 +69,6 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
       menuStyle: MenuStyle(
         elevation: WidgetStateProperty.all(6),
         backgroundColor: WidgetStateProperty.all(colorScheme.surfaceContainer),
-      ),
-    ),
-
-    // Icon theme.
-    iconTheme: IconThemeData(color: colorScheme.primary),
-
-    // Card theme.
-    cardTheme: CardThemeData(
-      color: colorScheme.surfaceContainerLow,
-      elevation: 1,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-    ),
-
-    // Input Field theme.
-    inputDecorationTheme: InputDecorationTheme(
-      filled: true,
-      fillColor: colorScheme.surfaceContainerHighest,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: colorScheme.outline),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: colorScheme.outline),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: colorScheme.primary, width: 2),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: colorScheme.error),
-      ),
-    ),
-
-    // Divider theme.
-    dividerTheme: DividerThemeData(
-      color: colorScheme.outlineVariant,
-      thickness: 1,
-    ),
-
-    // Bottom Sheet theme.
-    bottomSheetTheme: BottomSheetThemeData(
-      backgroundColor: colorScheme.surface,
-      surfaceTintColor: colorScheme.surfaceTint,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
     ),
   );

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Esri
+// Copyright 2026 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,30 +16,46 @@
 
 import 'package:flutter/material.dart';
 
-final colorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
+// Light Theme Color Scheme
+final lightColorScheme = ColorScheme.fromSeed(
+  seedColor: Colors.deepPurple,
+);
 
-final sampleViewerTheme = ThemeData(
-  // color scheme
-  primaryColor: colorScheme.primary,
-  primaryColorLight: Colors.deepPurple[200],
-  disabledColor: Colors.grey,
-  colorScheme: colorScheme,
+// Dark Theme Color Scheme
+final darkColorScheme = ColorScheme.fromSeed(
+  seedColor: Colors.deepPurple,
+  brightness: Brightness.dark,
+);
 
-  // application bar theme
-  appBarTheme: AppBarTheme(backgroundColor: colorScheme.inversePrimary),
 
-  // text theme
-  textTheme: const TextTheme(labelMedium: TextStyle(color: Colors.deepPurple)),
+// Light Theme
+final sampleViewerLightTheme = ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.light,
+  colorScheme: lightColorScheme,
+  primaryColor: lightColorScheme.primary,
 
-  // button theme
+  // Application bar theme
+  appBarTheme: AppBarTheme(
+    backgroundColor: lightColorScheme.inversePrimary,
+  ),
+
+  // Text theme
+  textTheme: const TextTheme(
+    labelMedium: TextStyle(color: Colors.deepPurple),
+  ),
+
+  // Button themes
   elevatedButtonTheme: ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       disabledBackgroundColor: Colors.white.withValues(alpha: 0.6),
     ),
   ),
+
   floatingActionButtonTheme: FloatingActionButtonThemeData(
-    backgroundColor: colorScheme.primaryContainer,
+    backgroundColor: lightColorScheme.primaryContainer,
   ),
+
   dropdownMenuTheme: DropdownMenuThemeData(
     inputDecorationTheme: const InputDecorationTheme(
       outlineBorder: BorderSide(width: 0),
@@ -48,8 +64,48 @@ final sampleViewerTheme = ThemeData(
     menuStyle: MenuStyle(elevation: WidgetStateProperty.all(6)),
   ),
 
-  // icon theme
-  iconTheme: IconThemeData(color: colorScheme.primary),
+  // Icon theme
+  iconTheme: IconThemeData(color: lightColorScheme.primary),
+);
+
+// Dark Theme
+final sampleViewerDarkTheme = ThemeData(
+  useMaterial3: true,
+  brightness: Brightness.dark,
+  colorScheme: darkColorScheme,
+  primaryColor: darkColorScheme.primary,
+
+  // Application bar theme
+  appBarTheme: AppBarTheme(
+    backgroundColor: darkColorScheme.inversePrimary,
+  ),
+
+  // Text theme - adjusted for dark mode
+  textTheme: TextTheme(
+    labelMedium: TextStyle(color: darkColorScheme.primary),
+  ),
+
+  // Button themes
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+      disabledBackgroundColor: Colors.black.withValues(alpha: 0.3),
+    ),
+  ),
+
+  floatingActionButtonTheme: FloatingActionButtonThemeData(
+    backgroundColor: darkColorScheme.primaryContainer,
+  ),
+
+  dropdownMenuTheme: DropdownMenuThemeData(
+    inputDecorationTheme: const InputDecorationTheme(
+      outlineBorder: BorderSide(width: 0),
+      border: InputBorder.none,
+    ),
+    menuStyle: MenuStyle(elevation: WidgetStateProperty.all(6)),
+  ),
+
+  // Icon theme
+  iconTheme: IconThemeData(color: darkColorScheme.primary),
 );
 
 extension CustomTextTheme on TextTheme {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Esri
+// Copyright 2026 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ void main() async {
       localeResolutionCallback: (locale, supportedLocales) {
         return locale;
       },
-      theme: sampleViewerTheme,
+      theme: sampleViewerLightTheme,
+      darkTheme: sampleViewerDarkTheme,
     ),
   );
 }

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Esri
+// Copyright 2026 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,5 +54,11 @@ void main() async {
 
   final router = routerConfigWithSample(sample, initialRoute);
 
-  runApp(MaterialApp.router(routerConfig: router, theme: sampleViewerTheme));
+  runApp(
+    MaterialApp.router(
+      routerConfig: router,
+      theme: sampleViewerLightTheme,
+      darkTheme: sampleViewerDarkTheme,
+    ),
+  );
 }

--- a/lib/utils/sample_skeleton_runner.dart
+++ b/lib/utils/sample_skeleton_runner.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 Esri
+// Copyright 2026 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,5 +29,11 @@ void main() {
     ArcGISEnvironment.apiKey = apiKey;
   }
 
-  runApp(MaterialApp(theme: sampleViewerTheme, home: const SampleWidget()));
+  runApp(
+    MaterialApp(
+      theme: sampleViewerLightTheme,
+      darkTheme: sampleViewerDarkTheme,
+      home: const SampleWidget(),
+    ),
+  );
 }


### PR DESCRIPTION
- Added dark theme values into `theme_data.dart`.
- Added `darkTheme:` property into our main and sample_runner.

# Output:

## Samples Overview:
<img width="300"  alt="Samples Overview Light Mode" src="https://github.com/user-attachments/assets/06a0574b-ba52-4ff1-aceb-e05503fc1740" />
<img width="300"  alt="Samples Overview Dark Mode" src="https://github.com/user-attachments/assets/69dcbac1-fd37-416b-bf89-997108cb4bca" />

## Samples List
<img width="300" alt="Samples List Light Mode" src="https://github.com/user-attachments/assets/16a9df3a-38a8-49e8-9059-49a405008581" />

<img width="300" alt="Samples List Dark Mode" src="https://github.com/user-attachments/assets/90a04432-0c6c-44fd-8826-d692f44980b5" />

## Inside a Sample
<img width="300" alt="Bottom Sheet Settings Light Mode" src="https://github.com/user-attachments/assets/04e39cb0-77fb-47ee-94dc-d276284a7d76" />

<img width="300" alt="Bottom Sheet Settings Dark Mode" src="https://github.com/user-attachments/assets/d6b85f3e-c6af-4bec-b1cf-47e81f6c0f25" />

