### PR TITLE
update flutter_lints and turn on unnecessary_underscores

### DIFF
--- a/lib/samples/display_clusters/display_clusters.dart
+++ b/lib/samples/display_clusters/display_clusters.dart
@@ -293,7 +293,7 @@ class GeoElementsTab extends StatelessWidget {
             child: ListView.separated(
               padding: const EdgeInsets.fromLTRB(8, 0, 8, 16),
               itemCount: geoElements.length,
-              separatorBuilder: (_, __) => const Divider(height: 0),
+              separatorBuilder: (_, _) => const Divider(height: 0),
               itemBuilder: (context, index) {
                 final name = geoElements[index].getName(index);
                 return ListTile(

--- a/linter_rules.yaml
+++ b/linter_rules.yaml
@@ -174,6 +174,7 @@ linter:
     unnecessary_string_escapes: true
     unnecessary_string_interpolations: true
     unnecessary_this: true
+    unnecessary_underscores: true
     unnecessary_to_list_in_spreads: true
     unrelated_type_equality_checks: true
     use_build_context_synchronously: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.15
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Update to the latest flutter_lints 6.0.0, which has one new lint `unnecessary_underscores`. Fixed the one instance of that warning.