### PR TITLE
ignore overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ migrate_working_dir/
 
 # Flutter/Dart/Pub related
 pubspec.lock
+pubspec_overrides.yaml
 **/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/


### PR DESCRIPTION
Add `pubspec_overrides.yaml` to `.gitignore` so that we can make local overrides without them getting picked up by git.