### PR TITLE
Turn on discarded_futures and fix warnings

### DIFF
--- a/lib/common/sample_state_support.dart
+++ b/lib/common/sample_state_support.dart
@@ -32,7 +32,7 @@ mixin SampleStateSupport<T extends StatefulWidget> on State<T> {
     bool showOK = false,
   }) {
     if (mounted) {
-      showAlertDialog(context, message, title: title, showOK: showOK);
+      showAlertDialog(context, message, title: title, showOK: showOK).ignore();
     }
   }
 }

--- a/lib/common/swatch_image.dart
+++ b/lib/common/swatch_image.dart
@@ -63,7 +63,8 @@ class _SwatchImageState extends State<SwatchImage> {
           .then((image) {
             // Signal that the swatch image is ready.
             _swatchCompleter.complete(image.getEncodedBuffer());
-          });
+          })
+          .ignore();
     });
   }
 

--- a/lib/sample_viewer_app.dart
+++ b/lib/sample_viewer_app.dart
@@ -94,7 +94,7 @@ class _SampleViewerAppState extends State<SampleViewerApp>
               final box = context.findRenderObject()! as RenderBox;
               final position = box.localToGlobal(box.size.center(Offset.zero));
 
-              context.push('/search', extra: position);
+              context.push('/search', extra: position).ignore();
             },
             child: const Icon(Icons.search),
           );

--- a/lib/samples/add_feature_collection_layer_from_table/add_feature_collection_layer_from_table.dart
+++ b/lib/samples/add_feature_collection_layer_from_table/add_feature_collection_layer_from_table.dart
@@ -106,7 +106,7 @@ class _AddFeatureCollectionLayerFromTableState
       attributes: {'Place': 'Current location'},
       geometry: point,
     );
-    pointTable.addFeature(feature);
+    pointTable.addFeature(feature).ignore();
 
     return pointTable;
   }
@@ -156,7 +156,7 @@ class _AddFeatureCollectionLayerFromTableState
       attributes: {'Boundary': 'AManAPlanACanalPanama'},
       geometry: polyline,
     );
-    polylineTable.addFeature(feature);
+    polylineTable.addFeature(feature).ignore();
 
     return polylineTable;
   }
@@ -211,7 +211,7 @@ class _AddFeatureCollectionLayerFromTableState
       attributes: {'Area': 'Restricted area'},
       geometry: polygon,
     );
-    polygonTable.addFeature(feature);
+    polygonTable.addFeature(feature).ignore();
 
     return polygonTable;
   }

--- a/lib/samples/add_feature_layers/add_feature_layers.dart
+++ b/lib/samples/add_feature_layers/add_feature_layers.dart
@@ -127,13 +127,13 @@ class _AddFeatureLayersState extends State<AddFeatureLayers>
       case Source.url:
         loadFeatureServiceFromUri();
       case Source.portalItem:
-        loadPortalItem();
+        loadPortalItem().ignore();
       case Source.geodatabase:
-        loadGeodatabase();
+        loadGeodatabase().ignore();
       case Source.geopackage:
-        loadGeopackage();
+        loadGeopackage().ignore();
       case Source.shapefile:
-        loadShapefile();
+        loadShapefile().ignore();
     }
   }
 

--- a/lib/samples/add_point_scene_layer/add_point_scene_layer.dart
+++ b/lib/samples/add_point_scene_layer/add_point_scene_layer.dart
@@ -79,6 +79,6 @@ class _AddPointSceneLayerState extends State<AddPointSceneLayer>
     // Disable the loading indicator when the layer is loaded.
     pointSceneLayer.load().then((_) {
       setState(() => _ready = true);
-    });
+    }).ignore();
   }
 }

--- a/lib/samples/add_raster_from_service/add_raster_from_service.dart
+++ b/lib/samples/add_raster_from_service/add_raster_from_service.dart
@@ -43,8 +43,8 @@ class _AddRasterFromServiceState extends State<AddRasterFromService>
 
   @override
   void dispose() {
-    _drawStatusChangedSubscription?.cancel();
-    _layerViewChangedSubscription?.cancel();
+    _drawStatusChangedSubscription?.cancel().ignore();
+    _layerViewChangedSubscription?.cancel().ignore();
     super.dispose();
   }
 

--- a/lib/samples/add_wfs_layer/add_wfs_layer.dart
+++ b/lib/samples/add_wfs_layer/add_wfs_layer.dart
@@ -81,7 +81,7 @@ class _AddWfsLayerState extends State<AddWfsLayer> with SampleStateSupport {
     // Add a listener for map navigation events.
     _mapViewController.onNavigationChanged.listen((isNavigating) {
       if (!isNavigating) {
-        loadFeatures();
+        loadFeatures().ignore();
       }
     });
 

--- a/lib/samples/analyze_network_with_subnetwork_trace/analyze_network_with_subnetwork_trace.dart
+++ b/lib/samples/analyze_network_with_subnetwork_trace/analyze_network_with_subnetwork_trace.dart
@@ -87,7 +87,7 @@ class _AnalyzeNetworkWithSubnetworkTraceState
       'I68VGU^nMurF',
     );
 
-    _setup();
+    _setup().ignore();
   }
 
   @override

--- a/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
+++ b/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
@@ -485,7 +485,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
     if (_ticker.isActive) {
       _ticker.stop();
     } else {
-      _ticker.start();
+      _ticker.start().ignore();
     }
     setState(() => _isPlaying = _ticker.isActive);
   }
@@ -556,7 +556,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
                     // Update the modal to show progress reset to 0
                     _modalStateSetter?.call(() {});
 
-                    _loadMissionFrames(mission);
+                    _loadMissionFrames(mission).ignore();
                   }
                 },
                 dropdownMenuEntries: Mission.values.map((mission) {
@@ -588,7 +588,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
       },
     ).whenComplete(() {
       _modalStateSetter = null;
-    });
+    }).ignore();
   }
 
   // Shows the camera settings in a bottom sheet.
@@ -671,7 +671,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
           },
         );
       },
-    );
+    ).ignore();
   }
 
   // Builds a labeled slider widget.

--- a/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
+++ b/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
@@ -199,7 +199,7 @@ class _AnimateImagesWithImageOverlayState
     _lastFrameTime = 0;
     // create a ticker to control the image frame animation.
     _ticker = _ticker ?? createTicker(_onTicker);
-    _ticker!.start();
+    _ticker!.start().ignore();
     setState(() => _started = true);
   }
 
@@ -278,6 +278,9 @@ class _AnimateImagesWithImageOverlayState
     );
 
     // Once the image frame is loaded, set it to the image overlay.
-    imageFrame.load().then((_) => _imageOverlay.imageFrame = imageFrame);
+    imageFrame
+        .load()
+        .then((_) => _imageOverlay.imageFrame = imageFrame)
+        .ignore();
   }
 }

--- a/lib/samples/apply_mosaic_rule_to_rasters/apply_mosaic_rule_to_rasters.dart
+++ b/lib/samples/apply_mosaic_rule_to_rasters/apply_mosaic_rule_to_rasters.dart
@@ -132,7 +132,7 @@ class _ApplyMosaicRuleToRastersState extends State<ApplyMosaicRuleToRasters>
 
   @override
   void dispose() {
-    _drawStatusSubscription?.cancel();
+    _drawStatusSubscription?.cancel().ignore();
     super.dispose();
   }
 

--- a/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
+++ b/lib/samples/authenticate_with_oauth/authenticate_with_oauth.dart
@@ -49,7 +49,8 @@ class _AuthenticateWithOAuthState extends State<AuthenticateWithOAuth>
           // ignore: avoid_print
           print('Error revoking tokens: $error');
         })
-        .whenComplete(Authenticator.clearCredentials);
+        .whenComplete(Authenticator.clearCredentials)
+        .ignore();
 
     super.dispose();
   }

--- a/lib/samples/authenticate_with_token/authenticate_with_token.dart
+++ b/lib/samples/authenticate_with_token/authenticate_with_token.dart
@@ -34,7 +34,7 @@ class _AuthenticateWithTokenState extends State<AuthenticateWithToken>
   @override
   void dispose() {
     // Log out by removing all credentials.
-    Authenticator.clearCredentials();
+    Authenticator.clearCredentials().ignore();
 
     super.dispose();
   }

--- a/lib/samples/change_viewpoint/change_viewpoint.dart
+++ b/lib/samples/change_viewpoint/change_viewpoint.dart
@@ -122,7 +122,7 @@ class _ChangeViewpointState extends State<ChangeViewpoint>
         }).toList(),
         onSelected: (viewpoint) {
           if (viewpoint != null) {
-            changeViewpoint(viewpoint);
+            changeViewpoint(viewpoint).ignore();
           }
         },
       ),

--- a/lib/samples/configure_clusters/configure_clusters.dart
+++ b/lib/samples/configure_clusters/configure_clusters.dart
@@ -262,7 +262,7 @@ class _ConfigureClustersState extends State<ConfigureClusters>
           onClose: () => Navigator.of(context).maybePop(),
         ),
       ),
-    );
+    ).ignore();
   }
 
   Widget buildSettings(BuildContext context) {

--- a/lib/samples/create_load_report/create_load_report.dart
+++ b/lib/samples/create_load_report/create_load_report.dart
@@ -69,7 +69,7 @@ class _CreateLoadReportState extends State<CreateLoadReport>
       'I68VGU^nMurF',
     );
 
-    _initUtilityNetwork();
+    _initUtilityNetwork().ignore();
   }
 
   @override

--- a/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
+++ b/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
@@ -130,7 +130,7 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
   // When the map is tapped, add a feature to the feature table.
   void onTap(Offset localPosition) {
     final mapPoint = _mapViewController.screenToLocation(screen: localPosition);
-    if (mapPoint != null) _addFeature(mapPoint);
+    if (mapPoint != null) _addFeature(mapPoint).ignore();
   }
 
   // Create a mobile geodatabase and a feature table to store location history.

--- a/lib/samples/display_clusters/display_clusters.dart
+++ b/lib/samples/display_clusters/display_clusters.dart
@@ -222,7 +222,7 @@ class _DisplayClustersState extends State<DisplayClusters>
           ),
         ),
       ),
-    );
+    ).ignore();
   }
 
   void toggleFeatureClustering() {

--- a/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
+++ b/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
@@ -146,7 +146,7 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
   void initState() {
     super.initState();
     _damageType = widget.arcGISFeature.attributes['typdamage'] as String?;
-    _loadAttachments();
+    _loadAttachments().ignore();
   }
 
   @override
@@ -159,7 +159,7 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
       _attachments = [];
       _isLoading = true;
       _damageType = widget.arcGISFeature.attributes['typdamage'] as String?;
-      _loadAttachments();
+      _loadAttachments().ignore();
     }
   }
 
@@ -254,12 +254,14 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
                 icon: const Icon(Icons.save),
                 onPressed: () {
                   // Save the attachment to the device.
-                  FilePicker.platform.saveFile(
-                    dialogTitle: 'Save Attachment',
-                    fileName: attachment.name,
-                    bytes: data,
-                    lockParentWindow: true,
-                  );
+                  FilePicker.platform
+                      .saveFile(
+                        dialogTitle: 'Save Attachment',
+                        fileName: attachment.name,
+                        bytes: data,
+                        lockParentWindow: true,
+                      )
+                      .ignore();
                 },
               ),
               IconButton(

--- a/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
+++ b/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
@@ -242,7 +242,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
               Navigator.of(context).pop();
               setState(() {
                 feature.geometry = mapPoint;
-                _model.updateFeature();
+                _model.updateFeature().ignore();
                 setState(() => _featureBottomSheetVisible = false);
               });
             },
@@ -250,7 +250,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
           ),
         ],
       ),
-    );
+    ).ignore();
   }
 
   void _editDamageType(Feature feature) {

--- a/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
+++ b/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
@@ -269,7 +269,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
 
                   // Update the feature's attribute with the selected value.
                   feature.attributes['typdamage'] = damageType.label;
-                  _model.updateFeature();
+                  _model.updateFeature().ignore();
 
                   setState(() {
                     _featureBottomSheetVisible = false;
@@ -280,7 +280,7 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
           ),
         );
       },
-    );
+    ).ignore();
   }
 
   Future<void> showCreateVersionModalBottomSheet(

--- a/lib/samples/filter_building_scene_layer/filter_building_scene_layer.dart
+++ b/lib/samples/filter_building_scene_layer/filter_building_scene_layer.dart
@@ -208,7 +208,7 @@ class _FilterBuildingSceneLayerState extends State<FilterBuildingSceneLayer>
           onClose: () => Navigator.of(context).maybePop(),
         ),
       ),
-    );
+    ).ignore();
   }
 }
 

--- a/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
+++ b/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
@@ -113,12 +113,14 @@ class _FindRouteInMobileMapPackageState
                           : null,
                       // When the card is tapped, navigate to a FindRouteInMap page.
                       onTap: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute<void>(
-                            builder: (context) =>
-                                FindRouteInMap(sampleData: data),
-                          ),
-                        );
+                        Navigator.of(context)
+                            .push(
+                              MaterialPageRoute<void>(
+                                builder: (context) =>
+                                    FindRouteInMap(sampleData: data),
+                              ),
+                            )
+                            .ignore();
                       },
                     ),
                   ),

--- a/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
+++ b/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
@@ -166,7 +166,7 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
           child: WebViewWidget(controller: _webViewController),
         ),
       ),
-    );
+    ).ignore();
   }
 
   // A helper method to update the initial scale of the provided HTML content to improve readability.

--- a/lib/samples/manage_bookmarks/manage_bookmarks.dart
+++ b/lib/samples/manage_bookmarks/manage_bookmarks.dart
@@ -176,7 +176,7 @@ class _ManageBookmarksState extends State<ManageBookmarks> {
 
     // Set the map on the controller and navigate to the first bookmark.
     _mapViewController.arcGISMap = map;
-    _mapViewController.setBookmark(_bookmarks.first);
+    _mapViewController.setBookmark(_bookmarks.first).ignore();
 
     // Set the ready state variable to true to enable the sample UI.
     setState(() => _ready = true);

--- a/lib/samples/manage_features/manage_features.dart
+++ b/lib/samples/manage_features/manage_features.dart
@@ -371,7 +371,7 @@ class _ManageFeaturesState extends State<ManageFeatures>
               ? (String? damageType) {
                   if (damageType != null) {
                     setState(() => _selectedDamageType = damageType);
-                    updateAttribute(_selectedFeature!, damageType);
+                    updateAttribute(_selectedFeature!, damageType).ignore();
                   }
                 }
               : null,

--- a/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
+++ b/lib/samples/match_viewpoint_of_geo_views/match_viewpoint_of_geo_views.dart
@@ -45,8 +45,8 @@ class _MatchViewpointOfGeoViewsState extends State<MatchViewpointOfGeoViews>
 
   @override
   void dispose() {
-    _mapViewViewpointChangedSubscription?.cancel();
-    _sceneViewViewpointChangedSubscription?.cancel();
+    _mapViewViewpointChangedSubscription?.cancel().ignore();
+    _sceneViewViewpointChangedSubscription?.cancel().ignore();
     super.dispose();
   }
 

--- a/lib/samples/navigate_route/navigate_route.dart
+++ b/lib/samples/navigate_route/navigate_route.dart
@@ -121,10 +121,10 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
 
   @override
   void dispose() {
-    _simulatedLocationDataSource.stop();
-    _startedSubscription?.cancel();
-    _autoPanModeSubscription?.cancel();
-    _flutterTts.stop();
+    _simulatedLocationDataSource.stop().ignore();
+    _startedSubscription?.cancel().ignore();
+    _autoPanModeSubscription?.cancel().ignore();
+    _flutterTts.stop().ignore();
     super.dispose();
   }
 

--- a/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
+++ b/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
@@ -263,15 +263,15 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
 
   @override
   void dispose() {
-    _flutterTts.stop();
-    _simulatedLocationDataSource?.stop();
-    _voiceGuidanceSubscription?.cancel();
-    _trackingStatusSubscription?.cancel();
-    _rerouteStartedSubscription?.cancel();
-    _rerouteCompletedSubscription?.cancel();
+    _flutterTts.stop().ignore();
+    _simulatedLocationDataSource?.stop().ignore();
+    _voiceGuidanceSubscription?.cancel().ignore();
+    _trackingStatusSubscription?.cancel().ignore();
+    _rerouteStartedSubscription?.cancel().ignore();
+    _rerouteCompletedSubscription?.cancel().ignore();
 
-    _autoPanModeChangedSubscription?.cancel();
-    _mapLoadingSubscription?.cancel();
+    _autoPanModeChangedSubscription?.cancel().ignore();
+    _mapLoadingSubscription?.cancel().ignore();
     super.dispose();
   }
 
@@ -421,7 +421,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
       updateProgress,
     );
     _rerouteStartedSubscription = _routeTracker.onRerouteStarted.listen((_) {
-      _flutterTts.speak('Rerouting');
+      _flutterTts.speak('Rerouting').ignore();
       setState(() => _routeStatus = 'Rerouting');
     });
     _rerouteCompletedSubscription = _routeTracker.onRerouteCompleted.listen((
@@ -438,7 +438,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
     _routeTracker.setSpeechEngineReady(() => false);
     _flutterTts.speak(nextDirection).then((value) {
       _routeTracker.setSpeechEngineReady(() => true);
-    });
+    }).ignore();
   }
 
   // Listen for tracking status changes and update the route status.

--- a/lib/samples/query_dynamic_entities/query_dynamic_entities.dart
+++ b/lib/samples/query_dynamic_entities/query_dynamic_entities.dart
@@ -392,7 +392,7 @@ class _DynamicEntityObservationTileState
   @override
   void dispose() {
     // Cancel the subscription to avoid memory leaks.
-    _subscription?.cancel();
+    _subscription?.cancel().ignore();
     _subscription = null;
     super.dispose();
   }

--- a/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
+++ b/lib/samples/set_up_location_driven_geotriggers/set_up_location_driven_geotriggers.dart
@@ -71,11 +71,11 @@ class _SetUpLocationDrivenGeotriggersState
   @override
   void dispose() {
     // Stop the location data source.
-    _locationDataSource.stop();
+    _locationDataSource.stop().ignore();
 
     // Cancel the geotrigger event subscriptions.
     for (final subscription in _streamSubscriptions) {
-      subscription.cancel();
+      subscription.cancel().ignore();
     }
     _streamSubscriptions.clear();
 
@@ -308,7 +308,7 @@ class _SetUpLocationDrivenGeotriggersState
           onClose: () => Navigator.of(context).maybePop(),
         ),
       ),
-    );
+    ).ignore();
   }
 
   // Creates the path used for the SimulatedLocationDataSource.

--- a/lib/samples/show_device_location/show_device_location.dart
+++ b/lib/samples/show_device_location/show_device_location.dart
@@ -53,9 +53,9 @@ class _ShowDeviceLocationState extends State<ShowDeviceLocation>
   @override
   void dispose() {
     // When exiting, stop the location data source and cancel subscriptions.
-    _locationDataSource.stop();
-    _statusSubscription?.cancel();
-    _autoPanModeSubscription?.cancel();
+    _locationDataSource.stop().ignore();
+    _statusSubscription?.cancel().ignore();
+    _autoPanModeSubscription?.cancel().ignore();
 
     super.dispose();
   }

--- a/lib/samples/show_device_location_history/show_device_location_history.dart
+++ b/lib/samples/show_device_location_history/show_device_location_history.dart
@@ -53,8 +53,8 @@ class _ShowDeviceLocationHistoryState extends State<ShowDeviceLocationHistory>
   @override
   void dispose() {
     // When exiting, stop the location data source and cancel subscriptions.
-    _locationDataSource.stop();
-    _locationSubscription?.cancel();
+    _locationDataSource.stop().ignore();
+    _locationSubscription?.cancel().ignore();
     _locationHistoryLineOverlay.graphics.clear();
     _locationHistoryPointOverlay.graphics.clear();
 

--- a/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
+++ b/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
@@ -62,10 +62,10 @@ class _ShowDeviceLocationWithNmeaDataSourcesState
   @override
   void dispose() {
     // Cancel all the subscriptions.
-    _nmeaDataSubscription?.cancel();
-    _autopanSubscription?.cancel();
-    _locationSubscription?.cancel();
-    _satelliteSubscription?.cancel();
+    _nmeaDataSubscription?.cancel().ignore();
+    _autopanSubscription?.cancel().ignore();
+    _locationSubscription?.cancel().ignore();
+    _satelliteSubscription?.cancel().ignore();
 
     super.dispose();
   }

--- a/lib/samples/show_device_location_with_nmea_data_sources/simulated_nmea_data_source.dart
+++ b/lib/samples/show_device_location_with_nmea_data_sources/simulated_nmea_data_source.dart
@@ -96,7 +96,7 @@ class SimulatedNmeaDataSource {
   void _shutdown() {
     if (!_running) return;
 
-    _nmeaMessagesController.close();
+    _nmeaMessagesController.close().ignore();
     if (_timer.isActive) _timer.cancel();
     _running = false;
   }

--- a/lib/samples/show_popup/show_popup.dart
+++ b/lib/samples/show_popup/show_popup.dart
@@ -118,6 +118,6 @@ class _ShowPopupState extends State<ShowPopup> with SampleStateSupport {
           },
         ),
       ),
-    );
+    ).ignore();
   }
 }

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -67,7 +67,8 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
           // ignore: avoid_print
           print('Error revoking tokens: $error');
         })
-        .whenComplete(Authenticator.clearCredentials);
+        .whenComplete(Authenticator.clearCredentials)
+        .ignore();
 
     super.dispose();
   }
@@ -173,9 +174,9 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
   void loadThumbnails() {
     _portal.user?.thumbnail?.loadBytes().then((bytes) {
       setState(() => _userThumbnail = bytes);
-    });
+    }).ignore();
     _portal.portalInfo?.thumbnail?.loadBytes().then((bytes) {
       setState(() => _organizationThumbnail = bytes);
-    });
+    }).ignore();
   }
 }

--- a/lib/samples/show_utility_associations/show_utility_associations.dart
+++ b/lib/samples/show_utility_associations/show_utility_associations.dart
@@ -83,7 +83,7 @@ class _ShowUtilityAssociationsState extends State<ShowUtilityAssociations>
         null;
     ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
 
-    _viewpointChangedSubscription?.cancel();
+    _viewpointChangedSubscription?.cancel().ignore();
 
     super.dispose();
   }

--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
@@ -59,7 +59,7 @@ class _SnapGeometryEditsWithUtilityNetworkRulesState
   @override
   void dispose() {
     // Release resources.
-    _canUndoSubscription?.cancel();
+    _canUndoSubscription?.cancel().ignore();
     _geodatabase?.close();
 
     super.dispose();
@@ -436,7 +436,7 @@ class _SnapGeometryEditsWithUtilityNetworkRulesState
 
     final geometry = _mapViewController.geometryEditor!.stop()!;
     _selectedFeature!.geometry = geometry;
-    _selectedFeature!.featureTable!.updateFeature(_selectedFeature!);
+    _selectedFeature!.featureTable!.updateFeature(_selectedFeature!).ignore();
 
     clearSelection();
   }
@@ -572,7 +572,8 @@ class _SnapSourceSwatchState extends State<SnapSourceSwatch> {
           .then((image) {
             // Signal that the swatch image is ready.
             _swatchCompleter.complete(image.getEncodedBuffer());
-          });
+          })
+          .ignore();
     });
   }
 

--- a/lib/samples/style_graphics_with_symbols/style_graphics_with_symbols.dart
+++ b/lib/samples/style_graphics_with_symbols/style_graphics_with_symbols.dart
@@ -51,7 +51,7 @@ class _StyleGraphicsWithSymbolsState extends State<StyleGraphicsWithSymbols>
     );
   }
 
-  void onMapViewReady() {
+  Future<void> onMapViewReady() async {
     // Create the map.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISOceans);
 
@@ -78,7 +78,7 @@ class _StyleGraphicsWithSymbolsState extends State<StyleGraphicsWithSymbols>
     _createText();
 
     // Update the extent to encompass all of the symbols.
-    _setExtent();
+    await _setExtent();
 
     // Set the ready state variable to true to enable the sample UI.
     setState(() => _ready = true);

--- a/lib/samples/trace_utility_network/trace_utility_network.dart
+++ b/lib/samples/trace_utility_network/trace_utility_network.dart
@@ -381,7 +381,7 @@ class _TraceUtilityNetworkState extends State<TraceUtilityNetwork>
     // Create UtilityElement by its source type.
     if (networkSource.sourceType == UtilityNetworkSourceType.junction) {
       // If the source type is a junction.
-      _createJunctionElement(feature, networkSource);
+      _createJunctionElement(feature, networkSource).ignore();
     } else if (networkSource.sourceType == UtilityNetworkSourceType.edge) {
       // If the source type is an edge.
       _createEdgeJunctionElement(feature, point);

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -67,7 +67,7 @@ class _CategoryCardState extends State<CategoryCard>
     );
 
     Future.delayed(Duration(milliseconds: widget.index * 120), () {
-      if (mounted) _controller.forward();
+      if (mounted) _controller.forward().ignore();
     });
   }
 
@@ -177,7 +177,7 @@ class _AnimatedIconState extends State<_AnimatedIcon>
     );
 
     Future.delayed(Duration(milliseconds: widget.index * 120), () {
-      if (mounted) _entryController.forward();
+      if (mounted) _entryController.forward().ignore();
     });
   }
 

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -62,7 +62,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   @override
   void initState() {
     super.initState();
-    _checkIfResourcesExist();
+    _checkIfResourcesExist().ignore();
   }
 
   @override

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -33,7 +33,6 @@ class ReadmePage extends StatefulWidget {
 
 class _ReadmePageState extends State<ReadmePage> {
   var _isLoading = true;
-  var _htmlData = '';
 
   final _controller = WebViewController();
 
@@ -41,24 +40,26 @@ class _ReadmePageState extends State<ReadmePage> {
   void initState() {
     super.initState();
 
-    _controller.setNavigationDelegate(
-      NavigationDelegate(
-        onNavigationRequest: (request) {
-          final uri = Uri.parse(request.url);
+    _controller
+        .setNavigationDelegate(
+          NavigationDelegate(
+            onNavigationRequest: (request) {
+              final uri = Uri.parse(request.url);
 
-          // Allow the view to load the initial 'about:blank' page.
-          if (uri.scheme == 'about') {
-            return NavigationDecision.navigate;
-          }
+              // Allow the view to load the initial 'about:blank' page.
+              if (uri.scheme == 'about') {
+                return NavigationDecision.navigate;
+              }
 
-          // Launch any other URL in the system browser (instead of this WebViewController).
-          launchUrl(uri, mode: LaunchMode.externalApplication);
-          return NavigationDecision.prevent;
-        },
-      ),
-    );
+              // Launch any other URL in the system browser (instead of this WebViewController).
+              launchUrl(uri, mode: LaunchMode.externalApplication).ignore();
+              return NavigationDecision.prevent;
+            },
+          ),
+        )
+        .ignore();
 
-    _fetchMarkDown();
+    _fetchMarkDown().ignore();
   }
 
   Future<void> _fetchMarkDown() async {
@@ -115,17 +116,11 @@ class _ReadmePageState extends State<ReadmePage> {
       </html>
     ''';
 
-      setState(() {
-        _htmlData = styledHtml;
-        _controller.loadHtmlString(_htmlData);
-        _isLoading = false;
-      });
+      await _controller.loadHtmlString(styledHtml);
+      setState(() => _isLoading = false);
     } else {
-      setState(() {
-        _htmlData = 'Failed to load README.md';
-        _controller.loadHtmlString(_htmlData);
-        _isLoading = false;
-      });
+      await _controller.loadHtmlString('Failed to load README.md');
+      setState(() => _isLoading = false);
     }
   }
 

--- a/lib/widgets/sample_info_popup_menu.dart
+++ b/lib/widgets/sample_info_popup_menu.dart
@@ -57,7 +57,7 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
       onSelected: (result) {
         switch (result) {
           case 'Website':
-            _launchSampleUrl();
+            _launchSampleUrl().ignore();
           default:
             _navigateTo(context, result);
         }
@@ -96,7 +96,7 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
     if (stack.isEmpty || stack.last.endsWith('/live')) {
       // If there is nothing on the stack from this sample, or if we're on the live
       // running sample, push the location onto the stack.
-      context.push(toLocation);
+      context.push(toLocation).ignore();
     } else {
       if (stack.last != toLocation) {
         if (stack.contains(toLocation)) {
@@ -104,7 +104,7 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
           context.pop();
         } else {
           // Otherwise push the new location onto the navigation stack.
-          context.push(toLocation);
+          context.push(toLocation).ignore();
         }
       }
     }

--- a/linter_rules.yaml
+++ b/linter_rules.yaml
@@ -56,6 +56,7 @@ linter:
     depend_on_referenced_packages: true
     deprecated_consistency: true
     directives_ordering: true
+    discarded_futures: true
     document_ignores: true
     empty_catches: true
     empty_constructor_bodies: true


### PR DESCRIPTION
Turn on the `discarded_futures` lint and fix warnings. This is mostly just calling `ignore()` on Futures that we have no reason to await on.