### PR TITLE
Add favorite samples support with persisted state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,8 @@ void main() async {
   // const apiKey = ''; // Your API Key here.
   ArcGISEnvironment.apiKey = apiKey;
 
+  WidgetsFlutterBinding.ensureInitialized();
+
   final prefs = await SharedPreferences.getInstance();
   FavoriteRepository.instance.initialize(prefs);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/router_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   // Supply your apiKey using the --dart-define-from-file command line argument.
@@ -29,6 +30,9 @@ void main() async {
   // Alternatively, replace the above line with the following and hard-code your apiKey here:
   // const apiKey = ''; // Your API Key here.
   ArcGISEnvironment.apiKey = apiKey;
+
+  final prefs = await SharedPreferences.getInstance();
+  FavoriteRepository.instance.initialize(prefs);
 
   final jsonString = await rootBundle.loadString(
     'assets/generated_samples_list.json',

--- a/lib/models/category.dart
+++ b/lib/models/category.dart
@@ -18,6 +18,11 @@ import 'package:flutter/material.dart';
 
 enum SampleCategory {
   all('All', Icons.apps, 'assets/category_images/all_background.webp'),
+  favorites(
+    'Favorites',
+    Icons.favorite,
+    'assets/category_images/all_background.webp',
+  ),
   analysis(
     'Analysis',
     Icons.analytics,

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -117,9 +117,11 @@ class FavoriteRepository {
       return;
     }
 
-    _sharedPreferences.setStringList(
-      'favorite_sample_keys',
-      _favoriteSampleKeys.toList(),
+    unawaited(
+      _sharedPreferences.setStringList(
+        'favorite_sample_keys',
+        _favoriteSampleKeys.toList(),
+      ),
     );
 
     _favoriteChangedController.add((sampleKey: sampleKey, value: value));

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -18,6 +18,7 @@
 import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/samples_widget_list.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Class that contains information about each of the samples.
 /// The metadata is taken from the sample's README.metadata.json data via generated_samples_list.json.
@@ -64,6 +65,11 @@ class Sample {
 
   String get key => _key;
 
+  bool get isFavorite => FavoriteRepository.instance.isFavorite(_key);
+
+  set isFavorite(bool value) =>
+      FavoriteRepository.instance.setFavorite(_key, value);
+
   List<DownloadableResource> get downloadableResources =>
       _downloadableResources;
 
@@ -71,4 +77,36 @@ class Sample {
   bool get hasDownloadableResources => _downloadableResources.isNotEmpty;
 
   Widget getSampleWidget() => _sampleWidget;
+}
+
+// Repository for managing favorite state of samples, persisted using SharedPreferences.
+// `instance` must be initialized with SharedPreferences before use by calling `initialize()`.
+class FavoriteRepository {
+  static final instance = FavoriteRepository();
+
+  late SharedPreferences _sharedPreferences;
+  late Set<String> _favoriteSampleKeys;
+
+  void initialize(SharedPreferences sharedPreferences) {
+    _sharedPreferences = sharedPreferences;
+    _favoriteSampleKeys =
+        (_sharedPreferences.getStringList('favorite_sample_keys') ??
+                const <String>[])
+            .toSet();
+  }
+
+  bool isFavorite(String sampleKey) => _favoriteSampleKeys.contains(sampleKey);
+
+  void setFavorite(String sampleKey, bool value) {
+    if (value) {
+      _favoriteSampleKeys.add(sampleKey);
+    } else {
+      _favoriteSampleKeys.remove(sampleKey);
+    }
+
+    _sharedPreferences.setStringList(
+      'favorite_sample_keys',
+      _favoriteSampleKeys.toList(),
+    );
+  }
 }

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -124,6 +124,8 @@ class FavoriteRepository {
       ),
     );
 
-    _favoriteChangedController.add((sampleKey: sampleKey, value: value));
+    if (_favoriteChangedController.hasListener) {
+      _favoriteChangedController.add((sampleKey: sampleKey, value: value));
+    }
   }
 }

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+import 'dart:async';
+
 // run `dart run build_runner build` to generate samples_widget_list.dart
 import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/samples_widget_list.dart';
@@ -79,14 +81,21 @@ class Sample {
   Widget getSampleWidget() => _sampleWidget;
 }
 
-// Repository for managing favorite state of samples, persisted using SharedPreferences.
-// `instance` must be initialized with SharedPreferences before use by calling `initialize()`.
+/// Repository for managing favorite state of samples, persisted using SharedPreferences.
+/// `instance` must be initialized with SharedPreferences before use by calling `initialize()`.
 class FavoriteRepository {
   static final instance = FavoriteRepository();
 
   late SharedPreferences _sharedPreferences;
   late Set<String> _favoriteSampleKeys;
+  final _favoriteChangedController =
+      StreamController<({String sampleKey, bool value})>.broadcast();
 
+  /// Stream that emits events when a favorite sample is added or removed.
+  Stream<({String sampleKey, bool value})> get favoriteChanged =>
+      _favoriteChangedController.stream;
+
+  /// Loads the favorite samples from SharedPreferences.
   void initialize(SharedPreferences sharedPreferences) {
     _sharedPreferences = sharedPreferences;
     _favoriteSampleKeys =
@@ -95,18 +104,24 @@ class FavoriteRepository {
             .toSet();
   }
 
+  /// Whether the sample with the given key is marked as a favorite.
   bool isFavorite(String sampleKey) => _favoriteSampleKeys.contains(sampleKey);
 
+  /// Sets the favorite status of the sample, persists the change, and emits an event.
   void setFavorite(String sampleKey, bool value) {
-    if (value) {
-      _favoriteSampleKeys.add(sampleKey);
-    } else {
-      _favoriteSampleKeys.remove(sampleKey);
+    final hasChanged = value
+        ? _favoriteSampleKeys.add(sampleKey)
+        : _favoriteSampleKeys.remove(sampleKey);
+
+    if (!hasChanged) {
+      return;
     }
 
     _sharedPreferences.setStringList(
       'favorite_sample_keys',
       _favoriteSampleKeys.toList(),
     );
+
+    _favoriteChangedController.add((sampleKey: sampleKey, value: value));
   }
 }

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -22,6 +22,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/router_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Run an individual sample outside of the Sample Viewer App.
 void main() async {
@@ -37,13 +38,20 @@ void main() async {
   // Alternatively, replace sample below with the directory name of the individual sample in snake case
   // const sampleFolderName = 'display_map';
 
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final prefs = await SharedPreferences.getInstance();
+  FavoriteRepository.instance.initialize(prefs);
+
   final jsonString = await rootBundle.loadString(
     'assets/generated_samples_list.json',
   );
   final sampleData = jsonDecode(jsonString) as Map<String, dynamic>;
+
   final allSamples = List<Sample>.unmodifiable(
     sampleData.values.whereType<Map<String, dynamic>>().map(Sample.fromJson),
   );
+
   final sample = allSamples.firstWhere((s) {
     return s.key == sampleFolderName;
   });

--- a/lib/widgets/sample_info_popup_menu.dart
+++ b/lib/widgets/sample_info_popup_menu.dart
@@ -68,9 +68,9 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
           case 'Website':
             _launchSampleUrl();
           case 'ToggleFavorite':
-            setState(() {
-              widget.sample.isFavorite = !widget.sample.isFavorite;
-            });
+            setState(
+              () => widget.sample.isFavorite = !widget.sample.isFavorite,
+            );
           default:
             _navigateTo(context, result);
         }

--- a/lib/widgets/sample_info_popup_menu.dart
+++ b/lib/widgets/sample_info_popup_menu.dart
@@ -34,23 +34,32 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
   Widget build(BuildContext context) {
     return PopupMenuButton(
       icon: const Icon(Icons.more_vert),
-      itemBuilder: (context) => const [
-        PopupMenuItem(
+      itemBuilder: (context) => [
+        const PopupMenuItem(
           value: 'README',
           child: ListTile(
             leading: Icon(Icons.description),
             title: Text('README'),
           ),
         ),
-        PopupMenuItem(
+        const PopupMenuItem(
           value: 'Code',
           child: ListTile(leading: Icon(Icons.source), title: Text('Code')),
         ),
-        PopupMenuItem(
+        const PopupMenuItem(
           value: 'Website',
           child: ListTile(
             leading: Icon(Icons.link_rounded),
             title: Text('Website'),
+          ),
+        ),
+        PopupMenuItem(
+          value: 'ToggleFavorite',
+          child: ListTile(
+            leading: Icon(
+              widget.sample.isFavorite ? Icons.favorite : Icons.favorite_border,
+            ),
+            title: Text(widget.sample.isFavorite ? 'Unfavorite' : 'Favorite'),
           ),
         ),
       ],
@@ -58,6 +67,10 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
         switch (result) {
           case 'Website':
             _launchSampleUrl();
+          case 'ToggleFavorite':
+            setState(() {
+              widget.sample.isFavorite = !widget.sample.isFavorite;
+            });
           default:
             _navigateTo(context, result);
         }

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -219,16 +219,21 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   }
 
   List<Sample> getSamplesByCategory(SampleCategory? category) {
-    if (category == null) {
-      return [];
+    switch (category) {
+      case null:
+        return [];
+      case .all:
+        return widget.allSamples;
+      case .favorites:
+        return widget.allSamples.where((sample) => sample.isFavorite).toList();
+      default:
+        return widget.allSamples
+            .where(
+              (sample) =>
+                  sample.category.toLowerCase() == category.title.toLowerCase(),
+            )
+            .toList();
     }
-    if (category.title == SampleCategory.all.title) {
-      return widget.allSamples;
-    }
-
-    return widget.allSamples.where((sample) {
-      return sample.category.toLowerCase() == category.title.toLowerCase();
-    }).toList();
   }
 
   void generateSearchHints() {

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -76,7 +76,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
 
   // Subscription to listen for changes in favorites if the current category is favorites.
   StreamSubscription<({String sampleKey, bool value})>?
-      _favoriteChangeSubscription;
+  _favoriteChangeSubscription;
 
   @override
   void initState() {
@@ -120,7 +120,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     _hintTimer.cancel();
     _textEditingController.dispose();
     _searchFocusNode.dispose();
-    _favoriteChangeSubscription?.cancel();
+    _favoriteChangeSubscription?.cancel().ignore();
     super.dispose();
   }
 

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -85,13 +85,11 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
       _filteredSamples = getSamplesByCategory(widget.category);
 
       if (widget.category == .favorites) {
+        // Refresh the list of samples when a favorite is added or removed.
         _favoriteChangeSubscription = FavoriteRepository
             .instance
             .favoriteChanged
-            .listen((_) {
-              // Refresh the list of samples when a favorite is added or removed.
-              onSearchChanged(_textEditingController.text);
-            });
+            .listen((_) => onSearchChanged(_textEditingController.text));
       }
     }
 

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -75,7 +75,8 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   late Timer _hintTimer;
 
   // Subscription to listen for changes in favorites if the current category is favorites.
-  StreamSubscription<dynamic>? _favoriteChangeSubscription;
+  StreamSubscription<({String sampleKey, bool value})>?
+      _favoriteChangeSubscription;
 
   @override
   void initState() {

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -74,12 +74,25 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   int _currentHintIndex = 0;
   late Timer _hintTimer;
 
+  // Subscription to listen for changes in favorites if the current category is favorites.
+  StreamSubscription<dynamic>? _favoriteChangeSubscription;
+
   @override
   void initState() {
     super.initState();
 
     if (widget.category != null) {
       _filteredSamples = getSamplesByCategory(widget.category);
+
+      if (widget.category == .favorites) {
+        _favoriteChangeSubscription = FavoriteRepository
+            .instance
+            .favoriteChanged
+            .listen((_) {
+              final refreshedSamples = getSamplesByCategory(.favorites);
+              setState(() => _filteredSamples = refreshedSamples);
+            });
+      }
     }
 
     generateSearchHints();
@@ -108,6 +121,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     _hintTimer.cancel();
     _textEditingController.dispose();
     _searchFocusNode.dispose();
+    _favoriteChangeSubscription?.cancel();
     super.dispose();
   }
 
@@ -237,6 +251,11 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   }
 
   void generateSearchHints() {
+    if (widget.category == .favorites) {
+      _hintMessages = ['Your favorite samples will appear here.'];
+      return;
+    }
+
     final uniqueHints = <String>{};
     final random = Random();
 

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -89,8 +89,8 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
             .instance
             .favoriteChanged
             .listen((_) {
-              final refreshedSamples = getSamplesByCategory(.favorites);
-              setState(() => _filteredSamples = refreshedSamples);
+              // Refresh the list of samples when a favorite is added or removed.
+              onSearchChanged(_textEditingController.text);
             });
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   package_info_plus: ^9.0.0
   path: ^1.9.1
   path_provider: ^2.1.5
+  shared_preferences: ^2.5.3
   share_plus: ^12.0.2
   simple_html_css: ^5.0.0
   url_launcher: ^6.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,8 @@ dependencies:
   package_info_plus: ^9.0.0
   path: ^1.9.1
   path_provider: ^2.1.5
-  shared_preferences: ^2.5.3
   share_plus: ^12.0.2
+  shared_preferences: ^2.5.3
   simple_html_css: ^5.0.0
   url_launcher: ^6.3.1
   webview_flutter: ^4.10.0


### PR DESCRIPTION
## Summary
- add favorites support to the sample browser by introducing a new Favorites category
- persist favorite sample keys in SharedPreferences via a centralized FavoriteRepository
- expose Sample.isFavorite as a model-level getter/setter backed by FavoriteRepository
- add a public favoriteChanged stream that emits (sampleKey, value) updates on favorite changes
- add favorite toggle action in the sample info popup menu
- refresh the Favorites view reactively when favorite changes are emitted
