### PR TITLE
Add Dark Mode support for README page

### DIFF
--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -33,7 +33,6 @@ class ReadmePage extends StatefulWidget {
 
 class _ReadmePageState extends State<ReadmePage> {
   var _isLoading = true;
-  var _htmlData = '';
   var _markdownHtml = '';
   Brightness? _lastBrightness;
 
@@ -166,8 +165,7 @@ class _ReadmePageState extends State<ReadmePage> {
       </html>
     ''';
 
-    _htmlData = styledHtml;
-    _controller.loadHtmlString(_htmlData);
+    _controller.loadHtmlString(styledHtml);
   }
 
   String _toCssColor(Color color) {

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -76,9 +76,9 @@ class _ReadmePageState extends State<ReadmePage> {
 
     _lastBrightness = brightness;
     if (_markdownHtml.isNotEmpty) {
-      Future.delayed(const Duration(milliseconds: 100), () {
+      Future.delayed(const Duration(milliseconds: 100), () async {
         if (!mounted) return;
-        _loadStyledHtml();
+        await _loadStyledHtml();
       }).ignore();
     }
   }
@@ -103,23 +103,15 @@ class _ReadmePageState extends State<ReadmePage> {
 
       // Convert the markdown to html.
       _markdownHtml = md.markdownToHtml(markdownData);
-
-      setState(() {
-        _isLoading = false;
-      });
-
-      _loadStyledHtml();
     } else {
-      setState(() {
-        _markdownHtml = '<p>Failed to load README.md</p>';
-        _isLoading = false;
-      });
-
-      _loadStyledHtml();
+      _markdownHtml = '<p>Failed to load README.md</p>';
     }
+
+    await _loadStyledHtml();
+    setState(() => _isLoading = false);
   }
 
-  void _loadStyledHtml() {
+  Future<void> _loadStyledHtml() async {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -167,7 +159,7 @@ class _ReadmePageState extends State<ReadmePage> {
       </html>
     ''';
 
-    _controller.loadHtmlString(styledHtml).ignore();
+    await _controller.loadHtmlString(styledHtml);
   }
 
   String _toCssColor(Color color) {

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -89,6 +89,8 @@ class _ReadmePageState extends State<ReadmePage> {
         'https://github.com/Esri/arcgis-maps-sdk-flutter-samples/raw/main/lib/samples/${widget.sample.key}/${widget.sample.key}.png';
 
     final response = await http.get(Uri.parse(readmeUrl));
+    if (!mounted) return;
+
     if (response.statusCode == 200) {
       var markdownData = response.body;
 

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -108,6 +108,8 @@ class _ReadmePageState extends State<ReadmePage> {
     }
 
     await _loadStyledHtml();
+    if (!mounted) return;
+
     setState(() => _isLoading = false);
   }
 

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -164,7 +164,8 @@ class _ReadmePageState extends State<ReadmePage> {
 
   String _toCssColor(Color color) {
     final hex = color.toARGB32().toRadixString(16).padLeft(8, '0');
-    return '#${hex.substring(2)}';
+    // Convert ARGB to RGBA for CSS.
+    return '#${hex.substring(2)}${hex.substring(0, 2)}';
   }
 
   @override

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -34,6 +34,8 @@ class ReadmePage extends StatefulWidget {
 class _ReadmePageState extends State<ReadmePage> {
   var _isLoading = true;
   var _htmlData = '';
+  var _markdownHtml = '';
+  Brightness? _lastBrightness;
 
   final _controller = WebViewController();
 
@@ -61,6 +63,25 @@ class _ReadmePageState extends State<ReadmePage> {
     _fetchMarkDown();
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // When the theme brightness changes, reload the HTML with the new theme colors.
+    final brightness = Theme.of(context).brightness;
+    if (_lastBrightness == brightness) {
+      return;
+    }
+
+    _lastBrightness = brightness;
+    if (_markdownHtml.isNotEmpty) {
+      Future.delayed(
+        const Duration(milliseconds: 100),
+        _loadStyledHtml,
+      ).ignore();
+    }
+  }
+
   Future<void> _fetchMarkDown() async {
     final readmeUrl =
         'https://raw.githubusercontent.com/Esri/arcgis-maps-sdk-flutter-samples/main/lib/samples/${widget.sample.key}/README.md';
@@ -78,28 +99,56 @@ class _ReadmePageState extends State<ReadmePage> {
       );
 
       // Convert the markdown to html.
-      final html = md.markdownToHtml(markdownData);
+      _markdownHtml = md.markdownToHtml(markdownData);
 
-      // Inject custom CSS for styling.
-      final styledHtml =
-          '''
+      setState(() {
+        _isLoading = false;
+      });
+
+      _loadStyledHtml();
+    } else {
+      setState(() {
+        _markdownHtml = '<p>Failed to load README.md</p>';
+        _isLoading = false;
+      });
+
+      _loadStyledHtml();
+    }
+  }
+
+  void _loadStyledHtml() {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final styledHtml =
+        '''
       <html>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <style>
+          :root {
+            color-scheme: ${theme.brightness == Brightness.dark ? 'dark' : 'light'};
+          }
           body {
+            background-color: ${_toCssColor(colorScheme.surface)};
+            color: ${_toCssColor(colorScheme.onSurface)};
             font-family: Arial, sans-serif;
             line-height: 1.6;
             padding: 16px;
             word-wrap: break-word;
             overflow-wrap: break-word;
           }
+          a {
+            color: ${_toCssColor(colorScheme.primary)};
+          }
           h1, h2, h3, h4, h5, h6 {
+            color: ${_toCssColor(colorScheme.onSurface)};
             font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
           }
           code {
-            background-color: #f5f5f5;
+            background-color: ${_toCssColor(colorScheme.surfaceContainer)};
             padding: 2px 4px;
+            color: ${_toCssColor(colorScheme.onSurface)};
             border-radius: 4px;
             font-family: 'Courier New', Courier, monospace;
           }
@@ -110,27 +159,24 @@ class _ReadmePageState extends State<ReadmePage> {
         </style>
       </head>
       <body>
-        $html
+        $_markdownHtml
       </body>
       </html>
     ''';
 
-      setState(() {
-        _htmlData = styledHtml;
-        _controller.loadHtmlString(_htmlData);
-        _isLoading = false;
-      });
-    } else {
-      setState(() {
-        _htmlData = 'Failed to load README.md';
-        _controller.loadHtmlString(_htmlData);
-        _isLoading = false;
-      });
-    }
+    _htmlData = styledHtml;
+    _controller.loadHtmlString(_htmlData);
+  }
+
+  String _toCssColor(Color color) {
+    final hex = color.toARGB32().toRadixString(16).padLeft(8, '0');
+    return '#${hex.substring(2)}';
   }
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Scaffold(
       appBar: AppBar(
         title: FittedBox(
@@ -143,12 +189,16 @@ class _ReadmePageState extends State<ReadmePage> {
         children: [
           Container(
             width: double.infinity,
-            color: Colors.grey[300],
-            child: const ListTile(
-              leading: Icon(Icons.description),
+            color: colorScheme.surfaceContainer,
+            child: ListTile(
+              leading: Icon(Icons.description, color: colorScheme.onSurface),
               title: Text(
                 'Readme',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -167,7 +167,7 @@ class _ReadmePageState extends State<ReadmePage> {
       </html>
     ''';
 
-    _controller.loadHtmlString(styledHtml);
+    _controller.loadHtmlString(styledHtml).ignore();
   }
 
   String _toCssColor(Color color) {

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -75,10 +75,10 @@ class _ReadmePageState extends State<ReadmePage> {
 
     _lastBrightness = brightness;
     if (_markdownHtml.isNotEmpty) {
-      Future.delayed(
-        const Duration(milliseconds: 100),
-        _loadStyledHtml,
-      ).ignore();
+      Future.delayed(const Duration(milliseconds: 100), () {
+        if (!mounted) return;
+        _loadStyledHtml();
+      }).ignore();
     }
   }
 


### PR DESCRIPTION
## Summary
- add dark mode support for the README page content rendered in the WebView
- make README HTML styling theme-aware by mapping Flutter `ColorScheme` values into CSS
- reload styled HTML when app brightness changes so open README pages update without navigation
- update the in-page "Readme" header container to use themed colors instead of hardcoded light values
- add a mounted guard in the delayed refresh path to prevent lifecycle issues during disposal

## Changes
- cache generated markdown HTML and restyle it based on current theme
- introduce helper conversion from Flutter `Color` to CSS hex format
- keep existing behavior for loading README markdown and external link launching
