### PR TITLE
Update v.next to require 300.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=3.11.1 <4.0.0'
 
 dependencies:
-  arcgis_maps: ^300.0.0
-  arcgis_maps_toolkit: ^300.0.0
+  arcgis_maps: ^300.1.0
+  arcgis_maps_toolkit: ^300.1.0
   async: ^2.12.0
   build: ^2.4.2
   build_config: ^1.1.2


### PR DESCRIPTION
Now that we've released 300.0 to main, v.next moves on to 300.1.