### PR TITLE
Migrate to enum shorthand syntax

### DIFF
--- a/lib/common/bottom_sheet_settings.dart
+++ b/lib/common/bottom_sheet_settings.dart
@@ -40,7 +40,7 @@ class BottomSheetSettings extends StatelessWidget {
     return Padding(
       padding: bottomSheetPadding(context),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisSize: .min,
         children: [
           Row(
             children: [

--- a/lib/common/busy_indicator.dart
+++ b/lib/common/busy_indicator.dart
@@ -27,7 +27,7 @@ class BusyIndicator extends StatelessWidget {
           width: 110,
           height: 90,
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: .center,
             children: [
               const SizedBox(
                 width: 30,

--- a/lib/common/loading_indicator.dart
+++ b/lib/common/loading_indicator.dart
@@ -40,7 +40,7 @@ class _LoadingIndicatorState extends State<LoadingIndicator> {
           color: Colors.white30,
           child: Center(
             child: Column(
-              mainAxisSize: MainAxisSize.min,
+              mainAxisSize: .min,
               children: [
                 const CircularProgressIndicator(),
                 if (widget.text != null) ...[

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -74,17 +74,11 @@ final sampleViewerLightTheme = _buildTheme(lightColorScheme);
 final sampleViewerDarkTheme = _buildTheme(darkColorScheme);
 
 extension CustomTextTheme on TextTheme {
-  TextStyle get customLabelStyle => const TextStyle(
-    fontSize: 18,
-    fontWeight: FontWeight.bold,
-    color: Colors.white,
-  );
+  TextStyle get customLabelStyle =>
+      const TextStyle(fontSize: 18, fontWeight: .bold, color: Colors.white);
 
-  TextStyle get categoryCardLabelStyle => const TextStyle(
-    fontSize: 16,
-    fontWeight: FontWeight.bold,
-    color: Colors.white,
-  );
+  TextStyle get categoryCardLabelStyle =>
+      const TextStyle(fontSize: 16, fontWeight: .bold, color: Colors.white);
 
   TextStyle get customErrorStyle => const TextStyle(color: Colors.red);
 

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -22,7 +22,7 @@ final lightColorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
 // Dark Theme Color Scheme
 final darkColorScheme = ColorScheme.fromSeed(
   seedColor: Colors.deepPurple,
-  brightness: Brightness.dark,
+  brightness: .dark,
 );
 
 // This shared builder ensures light and dark themes stay in sync.

--- a/lib/router_config.dart
+++ b/lib/router_config.dart
@@ -56,7 +56,7 @@ GoRouter routerConfig(List<Sample> allSamples) {
               final categoryName = state.pathParameters['category'];
               final category = SampleCategory.values.firstWhere(
                 (c) => c.name == categoryName,
-                orElse: () => SampleCategory.all,
+                orElse: () => .all,
               );
               return CategoryTransitionPage(
                 child: SampleViewerPage(

--- a/lib/sample_viewer_app.dart
+++ b/lib/sample_viewer_app.dart
@@ -116,10 +116,9 @@ class _ResponsiveCategoryGrid extends StatelessWidget {
         builder: (context, constraints) {
           final cardSize = switch (orientation) {
             // Two columns in portrait.
-            Orientation.portrait => (constraints.maxWidth - cardSpacing) / 2,
+            .portrait => (constraints.maxWidth - cardSpacing) / 2,
             // Four columns in landscape.
-            Orientation.landscape =>
-              (constraints.maxWidth - cardSpacing * 3) / 4,
+            .landscape => (constraints.maxWidth - cardSpacing * 3) / 4,
           };
 
           return Wrap(

--- a/lib/samples/add_custom_dynamic_entity_data_source/add_custom_dynamic_entity_data_source.dart
+++ b/lib/samples/add_custom_dynamic_entity_data_source/add_custom_dynamic_entity_data_source.dart
@@ -41,7 +41,6 @@ class _AddCustomDynamicEntityDataSourceState
   // Dynamic entity layer for identify.
   DynamicEntityLayer? _dynamicEntityLayer;
 
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/utils/sample_skeleton.dart
+++ b/lib/utils/sample_skeleton.dart
@@ -50,7 +50,7 @@ class _SampleWidgetState extends State<SampleWidget> with SampleStateSupport {
                   ),
                 ),
                 Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  mainAxisAlignment: .spaceEvenly,
                   children: [
                     // A button to perform a task.
                     ElevatedButton(
@@ -71,7 +71,7 @@ class _SampleWidgetState extends State<SampleWidget> with SampleStateSupport {
 
   Future<void> onMapViewReady() async {
     // Create a map with a topographic basemap style.
-    final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
+    final map = ArcGISMap.withBasemapStyle(.arcGISTopographic);
     _mapViewController.arcGISMap = map;
 
     // Perform some long-running setup task.

--- a/lib/widgets/about_info.dart
+++ b/lib/widgets/about_info.dart
@@ -34,7 +34,7 @@ class _AboutInfoState extends State<AboutInfo> {
     return Column(
       spacing: 20,
       children: [
-        Text(widget.title, style: const TextStyle(fontWeight: FontWeight.bold)),
+        Text(widget.title, style: const TextStyle(fontWeight: .bold)),
         Row(
           mainAxisAlignment: .spaceEvenly,
           children: [
@@ -42,7 +42,7 @@ class _AboutInfoState extends State<AboutInfo> {
               'Version',
               style: TextStyle(
                 color: Theme.of(context).primaryColor,
-                fontWeight: FontWeight.bold,
+                fontWeight: .bold,
               ),
             ),
             FutureBuilder(

--- a/lib/widgets/about_info.dart
+++ b/lib/widgets/about_info.dart
@@ -36,7 +36,7 @@ class _AboutInfoState extends State<AboutInfo> {
       children: [
         Text(widget.title, style: const TextStyle(fontWeight: FontWeight.bold)),
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          mainAxisAlignment: .spaceEvenly,
           children: [
             Text(
               'Version',
@@ -48,7 +48,7 @@ class _AboutInfoState extends State<AboutInfo> {
             FutureBuilder(
               future: _packageInfoFuture,
               builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.connectionState == .done) {
                   return Text(
                     '${snapshot.data?.version}.${snapshot.data?.buildNumber}',
                   );

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -113,7 +113,7 @@ class _CategoryCardState extends State<CategoryCard>
               children: [
                 _AnimatedCategoryBackground(category: widget.category),
                 Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisAlignment: .center,
                   children: [
                     _AnimatedIcon(
                       category: widget.category,
@@ -129,7 +129,7 @@ class _CategoryCardState extends State<CategoryCard>
                           widget.category.title,
                           style: Theme.of(context).textTheme.titleMedium
                               ?.copyWith(color: Colors.white),
-                          textAlign: TextAlign.center,
+                          textAlign: .center,
                         ),
                       ),
                     ),
@@ -207,7 +207,7 @@ class _AnimatedIconState extends State<_AnimatedIcon>
               padding: const EdgeInsets.all(8),
               decoration: const BoxDecoration(
                 color: Colors.black87,
-                shape: BoxShape.circle,
+                shape: .circle,
               ),
               child: Icon(widget.category.icon, size: 30, color: Colors.white),
             ),
@@ -235,7 +235,7 @@ class _AnimatedCategoryBackground extends StatelessWidget {
         children: [
           Image.asset(
             category.backgroundImage,
-            fit: BoxFit.cover,
+            fit: .cover,
             width: double.infinity,
             height: double.infinity,
           ),

--- a/lib/widgets/code_view_page.dart
+++ b/lib/widgets/code_view_page.dart
@@ -39,10 +39,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Text(widget.sample.title),
-        ),
+        title: FittedBox(fit: .scaleDown, child: Text(widget.sample.title)),
         actions: [SampleInfoPopupMenu(sample: widget.sample)],
       ),
       body: SafeArea(
@@ -60,7 +57,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
                     final codeString = snapshot.data!;
                     return SyntaxView(
                       code: codeString,
-                      syntax: Syntax.DART,
+                      syntax: .DART,
                       syntaxTheme: SyntaxTheme.vscodeLight(),
                     );
                   } else if (snapshot.hasError) {
@@ -79,7 +76,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
             Visibility(
               visible: codeMap.length > 1,
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                mainAxisAlignment: .spaceEvenly,
                 children: [
                   ElevatedButton(
                     onPressed: _selectedFileIndex > 0

--- a/lib/widgets/code_view_page.dart
+++ b/lib/widgets/code_view_page.dart
@@ -38,7 +38,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
     final fileName = filePath.split('/').last;
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final syntaxTheme = theme.brightness == Brightness.dark
+    final syntaxTheme = theme.brightness == .dark
         ? SyntaxTheme.vscodeDark()
         : SyntaxTheme.vscodeLight();
 
@@ -62,7 +62,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
                   fileName,
                   style: TextStyle(
                     fontSize: 16,
-                    fontWeight: FontWeight.bold,
+                    fontWeight: .bold,
                     color: colorScheme.onSurface,
                   ),
                 ),

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -87,12 +87,12 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
           padding: const EdgeInsets.all(40),
           child: Center(
             child: Column(
-              mainAxisSize: MainAxisSize.min,
+              mainAxisSize: .min,
               children: [
                 Text(
                   'This sample requires downloadable resources',
                   style: Theme.of(context).textTheme.titleMedium,
-                  textAlign: TextAlign.center,
+                  textAlign: .center,
                 ),
                 const SizedBox(height: 20),
                 // Download progress indicator
@@ -112,7 +112,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
                       Text(
                         '$_progress% download complete',
                         style: Theme.of(context).textTheme.bodyMedium,
-                        textAlign: TextAlign.center,
+                        textAlign: .center,
                       ),
                     ],
                   ),
@@ -122,7 +122,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
                   child: Text(
                     'The resources have been downloaded.',
                     style: Theme.of(context).textTheme.bodySmall,
-                    textAlign: TextAlign.center,
+                    textAlign: .center,
                   ),
                 ),
                 // Button [Download|Cancel|Open]
@@ -239,10 +239,10 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       if (mounted) {
         var message = 'Error downloading resources. Please try again.';
         if (e is ArcGISException &&
-            e.errorType == ArcGISExceptionType.commonUserDefinedFailure &&
+            e.errorType == .commonUserDefinedFailure &&
             (e.wrappedException is ArcGISException?) &&
             (e.wrappedException as ArcGISException?)?.errorType ==
-                ArcGISExceptionType.commonUserCanceled) {
+                .commonUserCanceled) {
           message = 'Cancelled';
         }
 

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -48,12 +48,12 @@ class _ReadmePageState extends State<ReadmePage> {
 
               // Allow the view to load the initial 'about:blank' page.
               if (uri.scheme == 'about') {
-                return NavigationDecision.navigate;
+                return .navigate;
               }
 
               // Launch any other URL in the system browser (instead of this WebViewController).
-              launchUrl(uri, mode: LaunchMode.externalApplication).ignore();
-              return NavigationDecision.prevent;
+              launchUrl(uri, mode: .externalApplication).ignore();
+              return .prevent;
             },
           ),
         )
@@ -128,10 +128,7 @@ class _ReadmePageState extends State<ReadmePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Text(widget.sample.title),
-        ),
+        title: FittedBox(fit: .scaleDown, child: Text(widget.sample.title)),
         actions: [SampleInfoPopupMenu(sample: widget.sample)],
       ),
       body: Column(

--- a/lib/widgets/readme_page.dart
+++ b/lib/widgets/readme_page.dart
@@ -124,7 +124,7 @@ class _ReadmePageState extends State<ReadmePage> {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <style>
           :root {
-            color-scheme: ${theme.brightness == Brightness.dark ? 'dark' : 'light'};
+            color-scheme: ${theme.brightness == .dark ? 'dark' : 'light'};
           }
           body {
             background-color: ${_toCssColor(colorScheme.surface)};
@@ -190,7 +190,7 @@ class _ReadmePageState extends State<ReadmePage> {
                 'Readme',
                 style: TextStyle(
                   fontSize: 16,
-                  fontWeight: FontWeight.bold,
+                  fontWeight: .bold,
                   color: colorScheme.onSurface,
                 ),
               ),

--- a/lib/widgets/sample_detail_page.dart
+++ b/lib/widgets/sample_detail_page.dart
@@ -28,7 +28,7 @@ class SampleDetailPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: FittedBox(fit: BoxFit.scaleDown, child: Text(sample.title)),
+        title: FittedBox(fit: .scaleDown, child: Text(sample.title)),
         leading: BackButton(onPressed: () => _handleBackNavigation(context)),
         actions: [SampleInfoPopupMenu(sample: sample)],
       ),

--- a/lib/widgets/sample_info_popup_menu.dart
+++ b/lib/widgets/sample_info_popup_menu.dart
@@ -66,7 +66,7 @@ class _SampleInfoPopupMenuState extends State<SampleInfoPopupMenu>
   }
 
   Future<void> _launchSampleUrl() async {
-    if (!await launchUrl(webPageUrl(), mode: LaunchMode.externalApplication)) {
+    if (!await launchUrl(webPageUrl(), mode: .externalApplication)) {
       showMessageDialog('Could not launch ${webPageUrl()}');
     }
   }

--- a/lib/widgets/sample_viewer_page.dart
+++ b/lib/widgets/sample_viewer_page.dart
@@ -115,8 +115,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title:
-            (widget.category != null && widget.category != SampleCategory.all)
+        title: (widget.category != null && widget.category != .all)
             ? Text(widget.category!.title)
             : const Text(applicationTitle),
       ),
@@ -161,7 +160,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
                         child: Text(
                           _hintMessages[_currentHintIndex],
                           key: ValueKey(_currentHintIndex),
-                          textAlign: TextAlign.center,
+                          textAlign: .center,
                         ),
                       ),
                     )
@@ -189,13 +188,13 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     if (searchText.isEmpty) {
       if (widget.category == null) {
         results = [];
-      } else if (widget.category == SampleCategory.all) {
+      } else if (widget.category == .all) {
         results = widget.allSamples;
       } else {
         results = getSamplesByCategory(widget.category);
       }
     } else {
-      if (widget.category == null || widget.category == SampleCategory.all) {
+      if (widget.category == null || widget.category == .all) {
         results = widget.allSamples.where((sample) {
           final lowerSearchText = searchText.toLowerCase();
           return sample.title.toLowerCase().contains(lowerSearchText) ||
@@ -222,7 +221,7 @@ class _SampleViewerPageState extends State<SampleViewerPage> {
     if (category == null) {
       return [];
     }
-    if (category.title == SampleCategory.all.title) {
+    if (category == .all) {
       return widget.allSamples;
     }
 

--- a/tool/generate_new_sample.dart
+++ b/tool/generate_new_sample.dart
@@ -138,7 +138,7 @@ void createNewSampleFile(
         final newLine = line.replaceAll('SampleWidget', sampleCamelName);
         sampleFile.writeAsStringSync(
           '$newLine${Platform.lineTerminator}',
-          mode: FileMode.append,
+          mode: .append,
         );
       }
     }


### PR DESCRIPTION
Migrate Dart enum usage to enum shorthand syntax in the Sample Viewer code (but not the individual samples).

This was an AI-driven mechanical migration of just replacing, e.g., `FontWeight.bold`, with `.bold` where possible.
