### PR TITLE
Harish/dark theme UI fixes

### DIFF
--- a/lib/common/callout_theme.dart
+++ b/lib/common/callout_theme.dart
@@ -62,6 +62,8 @@ extension ThemedCalloutStyle on CalloutStyle {
           contentPadding ??
           const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       maxWidth: maxWidth ?? 300,
+      //CalloutStyle default Offset value.
+      offset: offset ?? const Offset(0, -8),
       minWidth: 100,
     );
   }

--- a/lib/common/callout_theme.dart
+++ b/lib/common/callout_theme.dart
@@ -1,3 +1,18 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/common/callout_theme.dart
+++ b/lib/common/callout_theme.dart
@@ -59,12 +59,10 @@ extension ThemedCalloutStyle on CalloutStyle {
 
       // Layout properties.
       contentPadding:
-      contentPadding ??
+          contentPadding ??
           const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      offset: offset ?? const Offset(0, -35),
       maxWidth: maxWidth ?? 300,
       minWidth: 100,
     );
   }
-
 }

--- a/lib/common/callout_theme.dart
+++ b/lib/common/callout_theme.dart
@@ -1,0 +1,55 @@
+import 'package:arcgis_maps/arcgis_maps.dart';
+import 'package:flutter/material.dart';
+
+/// Extension to create theme-aware CalloutStyle for ArcGIS MapView callouts.
+///
+/// Ensures callouts automatically adapt to light/dark mode using Material 3
+/// ColorScheme values instead of hard-coded Colors.white/black.
+extension ThemedCalloutStyle on CalloutStyle {
+  /// Creates a CalloutStyle that respects the current theme's ColorScheme.
+  ///
+  /// Usage:
+  /// ```dart
+  /// _mapViewController.callout.showAt(
+  ///   point,
+  ///   detail: 'Address text',
+  ///   style: CalloutStyle.themed(context),
+  /// );
+  /// ```
+  static CalloutStyle themed(
+    BuildContext context, {
+    EdgeInsets? contentPadding,
+    Offset? offset,
+    double? maxWidth,
+  }) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return CalloutStyle(
+      // Use elevated surface color for better visual hierarchy
+      backgroundColor: colorScheme.surfaceContainerHigh,
+
+      // Border color with theme-aware opacity
+      borderColor: colorScheme.outline.withValues(alpha: 0.3),
+      borderRadius: 12,
+
+      // Text styles that respect theme colors
+      titleTextStyle: textTheme.titleMedium?.copyWith(
+        color: colorScheme.onSurface,
+        fontWeight: FontWeight.w600,
+      ),
+      detailTextStyle: textTheme.bodyMedium?.copyWith(
+        color: colorScheme.onSurfaceVariant,
+      ),
+
+      // Layout properties (use provided values or sensible defaults)
+      contentPadding:
+          contentPadding ??
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      offset: offset ?? const Offset(0, -35),
+      maxWidth: maxWidth ?? 300,
+      minWidth: 100,
+    );
+  }
+}

--- a/lib/common/callout_theme.dart
+++ b/lib/common/callout_theme.dart
@@ -40,7 +40,6 @@ extension ThemedCalloutStyle on CalloutStyle {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
-
     return CalloutStyle(
       // Use elevated surface color for better visual hierarchy
       backgroundColor: colorScheme.surfaceContainerHigh,
@@ -58,13 +57,14 @@ extension ThemedCalloutStyle on CalloutStyle {
         color: colorScheme.onSurfaceVariant,
       ),
 
-      // Layout properties (use provided values or sensible defaults)
+      // Layout properties.
       contentPadding:
-          contentPadding ??
+      contentPadding ??
           const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       offset: offset ?? const Offset(0, -35),
       maxWidth: maxWidth ?? 300,
       minWidth: 100,
     );
   }
+
 }

--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -15,6 +15,7 @@
 //
 
 export 'bottom_sheet_settings.dart';
+export 'callout_theme.dart';
 export 'dialogs.dart';
 export 'download_util.dart';
 export 'feature_popup_view.dart';

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -62,6 +62,12 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
       foregroundColor: colorScheme.onPrimaryContainer,
     ),
 
+    // Icon theme for dropdown arrows and other icons.
+    iconTheme: IconThemeData(
+      color: colorScheme.onSurface,  // Light: dark grey, Dark: light grey
+      size: 24,
+    ),
+
     // Dropdown menu theme.
     dropdownMenuTheme: DropdownMenuThemeData(
       inputDecorationTheme: const InputDecorationTheme(
@@ -72,6 +78,27 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
         elevation: WidgetStateProperty.all(6),
         backgroundColor: WidgetStateProperty.all(colorScheme.surfaceContainer),
       ),
+      textStyle: TextStyle(color: colorScheme.onSurface),
+    ),
+
+    // Controls DropdownButton menu appearance.
+    popupMenuTheme: PopupMenuThemeData(
+      color: colorScheme.surfaceContainerHigh,
+      elevation: 6,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      textStyle: TextStyle(
+        color: colorScheme.onSurface,
+        fontSize: 14,
+      ),
+    ),
+
+    // Text selection theme (affects dropdown selected items).
+    textSelectionTheme: TextSelectionThemeData(
+      cursorColor: colorScheme.primary,
+      selectionColor: colorScheme.primaryContainer,
+      selectionHandleColor: colorScheme.primary,
     ),
 
     // Progress Indicator theme.
@@ -114,3 +141,4 @@ extension CustomTextTheme on TextTheme {
 
   TextStyle get customWhiteStyle => const TextStyle(color: Colors.white);
 }
+

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -19,10 +19,17 @@ import 'package:flutter/material.dart';
 // Light Theme Color Scheme
 final lightColorScheme = ColorScheme.fromSeed(seedColor: Colors.deepPurple);
 
-// Dark Theme Color Scheme
+// Dark Theme Color Scheme with softer surfaces.
 final darkColorScheme = ColorScheme.fromSeed(
   seedColor: Colors.deepPurple,
   brightness: .dark,
+  // Surfaces for Material-style soft dark tones.
+  surface: const Color(0xFF2C2C2E),
+  surfaceContainerLowest: const Color(0xFF1C1C1E),
+  surfaceContainerLow: const Color(0xFF232326),
+  surfaceContainer: const Color(0xFF2C2C2E),
+  surfaceContainerHigh: const Color(0xFF36363A),
+  surfaceContainerHighest: const Color(0xFF42424A),
 );
 
 // This shared builder ensures light and dark themes stay in sync.
@@ -30,6 +37,8 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
   return ThemeData(
     brightness: colorScheme.brightness,
     colorScheme: colorScheme,
+
+    scaffoldBackgroundColor: colorScheme.surface,
 
     // Application bar theme.
     appBarTheme: AppBarTheme(backgroundColor: colorScheme.inversePrimary),
@@ -63,6 +72,27 @@ ThemeData _buildTheme(ColorScheme colorScheme) {
         elevation: WidgetStateProperty.all(6),
         backgroundColor: WidgetStateProperty.all(colorScheme.surfaceContainer),
       ),
+    ),
+
+    // Progress Indicator theme.
+    progressIndicatorTheme: ProgressIndicatorThemeData(
+      color: colorScheme.primary,
+      linearTrackColor: colorScheme.surfaceContainerHighest,
+      circularTrackColor: colorScheme.surfaceContainerHighest,
+      linearMinHeight: 6,
+    ),
+
+    // Dialog theme with surface background color.
+    dialogTheme: DialogThemeData(
+      backgroundColor: colorScheme.surface,
+      elevation: 6,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    ),
+
+    cardTheme: CardThemeData(
+      color: colorScheme.surfaceContainerHigh,
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     ),
   );
 }

--- a/lib/samples/add_custom_dynamic_entity_data_source/add_custom_dynamic_entity_data_source.dart
+++ b/lib/samples/add_custom_dynamic_entity_data_source/add_custom_dynamic_entity_data_source.dart
@@ -158,6 +158,7 @@ concatenate(
 )
 ''',
       animated: false,
+      style: ThemedCalloutStyle.themed(context),
     );
   }
 }

--- a/lib/samples/add_dynamic_entity_layer/add_dynamic_entity_layer.dart
+++ b/lib/samples/add_dynamic_entity_layer/add_dynamic_entity_layer.dart
@@ -292,6 +292,7 @@ class _AddDynamicEntityLayerState extends State<AddDynamicEntityLayer>
               "\n(", Round($feature.point_x, 6), ", ", Round($feature.point_y, 6), ")"
             )
             ''',
+      style: ThemedCalloutStyle.themed(context),
     );
 
     if (!shown) {

--- a/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
+++ b/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
@@ -35,28 +35,40 @@ class _AnimateImagesWithImageOverlayState
     with TickerProviderStateMixin, SampleStateSupport {
   // Create a controller for the scene view.
   final _sceneViewController = ArcGISSceneView.createController();
+
   // A flag to toggle the start/stop of the image animation.
   var _started = false;
+
   // Define the animated speeds available in the dropdown button.
   final _animatedSpeeds = ['Fast', 'Medium', 'Slow'];
+
   // The initial selected animated speed.
   var _selectedAnimatedSpeed = 'Slow';
+
   // The speed of the image frame animation in milliseconds.
   var _imageFrameSpeed = 0;
+
   // The last frame time in milliseconds to control the animation speed.
   var _lastFrameTime = 0;
+
   // The initial opacity of the image overlay.
   var _opacity = 0.5;
+
   // Create an ImageOverlay to display the animated images.
   final _imageOverlay = ImageOverlay();
+
   // A list to hold the ArcGIS image files for the animation.
   List<File> _imageFileList = [];
+
   // An integer to track the current ArcGIS image index.
   var _imageFrameIndex = 0;
+
   // A timer to control and change the ArcGIS image periodically.
   Ticker? _ticker;
+
   // A flag for when the scene view is ready and controls can be used.
   var _ready = false;
+
   // The image envelope defines the extent of the image frame.
   final imageEnvelope = Envelope.fromCenter(
     ArcGISPoint(
@@ -131,12 +143,7 @@ class _AnimateImagesWithImageOverlayState
                       items: _animatedSpeeds.map((speed) {
                         return DropdownMenuItem<String>(
                           value: speed,
-                          child: Text(
-                            speed,
-                            style: TextStyle(
-                              color: Theme.of(context).primaryColor,
-                            ),
-                          ),
+                          child: Text(speed),
                         );
                       }).toList(),
                     ),

--- a/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
+++ b/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/download_progress_card.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -320,32 +321,11 @@ class _DownloadVectorTilesToLocalCacheState
 
   // Return a Widget with a linear progress bar.
   Widget buildProgressIndicator() {
-    return Container(
-      color: Colors.white,
-      constraints: BoxConstraints(
-        maxWidth: MediaQuery.sizeOf(context).width * 0.6,
-      ),
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 20,
-        children: [
-          Text('Downloading...', style: Theme.of(context).textTheme.labelLarge),
-          Text(
-            '${(_progress * 100).toStringAsFixed(0)}% completed',
-            style: Theme.of(context).textTheme.labelMedium,
-          ),
-          LinearProgressIndicator(
-            value: _progress,
-            backgroundColor: Colors.grey[200],
-            color: Colors.blue,
-          ),
-          ElevatedButton(
-            onPressed: cancelDownloadingJob,
-            child: const Text('Cancel Job'),
-          ),
-        ],
-      ),
+    return DownloadProgressCard(
+      title: 'Downloading...',
+      progress: _progress,
+      onCancel: cancelDownloadingJob,
+      cancelLabel: 'Cancel Job',
     );
   }
 }

--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
@@ -135,7 +135,7 @@ class _FindAddressWithReverseGeocodeState
     _mapViewController.callout.showAt(
       normalizedTapPoint,
       detail: combinedString,
-      style: ThemedCalloutStyle.themed(context),
+      style: ThemedCalloutStyle.themed(context, offset: const Offset(0, -35)),
     );
   }
 }

--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
@@ -35,6 +35,7 @@ class _FindAddressWithReverseGeocodeState
       'https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer',
     ),
   );
+
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
   final _initialViewpoint = Viewpoint.fromCenter(
@@ -45,6 +46,7 @@ class _FindAddressWithReverseGeocodeState
     ),
     scale: 50000,
   );
+
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
 
@@ -133,10 +135,7 @@ class _FindAddressWithReverseGeocodeState
     _mapViewController.callout.showAt(
       normalizedTapPoint,
       detail: combinedString,
-      style: CalloutStyle(
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        offset: const Offset(0, -35),
-      ),
+      style: ThemedCalloutStyle.themed(context),
     );
   }
 }

--- a/lib/samples/generate_offline_map/generate_offline_map.dart
+++ b/lib/samples/generate_offline_map/generate_offline_map.dart
@@ -18,6 +18,7 @@ import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/widgets/download_progress_card.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -107,33 +108,12 @@ class _GenerateOfflineMapState extends State<GenerateOfflineMap>
             // Display a progress indicator and a cancel button during the offline map generation.
             Visibility(
               visible: _progress != null,
-              child: Center(
-                child: Container(
-                  width: MediaQuery.sizeOf(context).width / 2,
-                  padding: const EdgeInsets.all(20),
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    spacing: 20,
-                    children: [
-                      // Add a progress indicator.
-                      Text('$_progress%'),
-                      LinearProgressIndicator(
-                        value: _progress != null ? _progress! / 100.0 : 0.0,
-                      ),
-                      // Add a button to cancel the job.
-                      ElevatedButton(
-                        onPressed: () => _generateOfflineMapJob?.cancel(),
-                        child: const Text('Cancel'),
-                      ),
-                    ],
-                  ),
-                ),
+              child: DownloadProgressCard(
+                title: 'Generating Offline Map',
+                progress: _progress != null ? _progress! / 100.0 : 0.0,
+                onCancel: () => _generateOfflineMapJob?.cancel(),
               ),
-            ),
+            )
           ],
         ),
       ),

--- a/lib/samples/identify_raster_cell/identify_raster_cell.dart
+++ b/lib/samples/identify_raster_cell/identify_raster_cell.dart
@@ -29,8 +29,10 @@ class _IdentifyRasterCellState extends State<IdentifyRasterCell>
     with SampleStateSupport {
   // Create a controller for the map view.
   final _mapViewController = ArcGISMapView.createController();
+
   // A flag for when the map view is ready and controls can be used.
   var _ready = false;
+
   // Raster layer to display raster data on the map.
   late RasterLayer _rasterLayer;
 
@@ -95,13 +97,8 @@ class _IdentifyRasterCellState extends State<IdentifyRasterCell>
         // Display a callout for the raster cell attributes.
         _mapViewController.callout.showCalloutForGeoElement(
           cell,
-          contentBuilder: (context, geoElement) => IntrinsicWidth(
-            child: Container(
-              padding: const EdgeInsets.all(6),
-              color: Colors.white,
-              child: Text(stringBuffer.toString(), softWrap: false),
-            ),
-          ),
+          detail: stringBuffer.toString(),
+          style: ThemedCalloutStyle.themed(context),
         );
       }
     }

--- a/lib/samples/show_line_of_sight_analysis_in_map/show_line_of_sight_analysis_in_map.dart
+++ b/lib/samples/show_line_of_sight_analysis_in_map/show_line_of_sight_analysis_in_map.dart
@@ -267,6 +267,7 @@ class _ShowLineOfSightAnalysisInMapState
       observerGraphic,
       title: observer.name,
       detail: lineOfSightResult.detail,
+      style: ThemedCalloutStyle.themed(context),
     );
   }
 }

--- a/lib/samples/show_realistic_light_and_shadows/show_realistic_light_and_shadows.dart
+++ b/lib/samples/show_realistic_light_and_shadows/show_realistic_light_and_shadows.dart
@@ -83,12 +83,7 @@ class _ShowRealisticLightAndShadowsState
                           .map(
                             (label) => DropdownMenuItem(
                               value: label,
-                              child: Text(
-                                label,
-                                style: TextStyle(
-                                  color: Theme.of(context).primaryColor,
-                                ),
-                              ),
+                              child: Text(label),
                             ),
                           )
                           .toList(),
@@ -114,7 +109,8 @@ class _ShowRealisticLightAndShadowsState
                         padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
                         child: Slider(
                           max: 24,
-                          divisions: 24 * 4, // 15-minute increments
+                          divisions: 24 * 4,
+                          // 15-minute increments
                           value: _timeValue,
                           label: '${_timeValue.toStringAsFixed(2)} h',
                           onChanged: (value) {
@@ -138,7 +134,7 @@ class _ShowRealisticLightAndShadowsState
                       child: Text(
                         // Format the sun time as [MMMM dd, yyyy, hh:mm a]
                         _dateFormat.format(_sunTime),
-                        style: TextStyle(color: Theme.of(context).primaryColor),
+                        style: Theme.of(context).textTheme.bodyMedium,
                       ),
                     ),
                   ],

--- a/lib/samples/show_utility_associations/show_utility_associations.dart
+++ b/lib/samples/show_utility_associations/show_utility_associations.dart
@@ -102,10 +102,10 @@ class _ShowUtilityAssociationsState extends State<ShowUtilityAssociations>
           SafeArea(
             child: Align(
               alignment: Alignment.topLeft,
-              child: Container(
+              child: Card(
                 margin: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.9),
+                elevation: 4,
+                shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Padding(
@@ -115,27 +115,44 @@ class _ShowUtilityAssociationsState extends State<ShowUtilityAssociations>
                     crossAxisAlignment: CrossAxisAlignment.start,
                     spacing: 5,
                     children: [
-                      const Text('Utility association types'),
+                      Text(
+                        'Utility association types',
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
                       Container(
                         decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey),
+                          border: Border.all(
+                            color: Theme.of(context).colorScheme.outlineVariant,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
                         ),
                         padding: const EdgeInsets.fromLTRB(5, 5, 50, 5),
                         child: Column(
                           mainAxisSize: MainAxisSize.min,
+                          spacing: 6,
                           children: [
                             Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 SwatchImage(symbol: _attachmentSymbol),
-                                const Text('Attachment'),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'Attachment',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
                               ],
                             ),
                             Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 SwatchImage(symbol: _connectivitySymbol),
-                                const Text('Connectivity'),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'Connectivity',
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
                               ],
                             ),
                           ],

--- a/lib/widgets/download_progress_card.dart
+++ b/lib/widgets/download_progress_card.dart
@@ -1,4 +1,4 @@
-// Copyright 2024 Esri
+// Copyright 2026 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/widgets/download_progress_card.dart
+++ b/lib/widgets/download_progress_card.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+/// A reusable, dialog-like card widget for displaying download/job progress.
+///
+class DownloadProgressCard extends StatelessWidget {
+
+  const DownloadProgressCard({
+    required this.title, required this.progress, super.key,
+    this.onCancel,
+    this.cancelLabel,
+    this.showPercentage = true,
+  });
+  /// Title displayed at the top of the progress card.
+  final String title;
+
+  /// Progress value from 0.0 (0%) to 1.0 (100%).
+  final double progress;
+
+  /// Callback invoked when the cancel button is pressed.
+  final VoidCallback? onCancel;
+
+  /// Optional: Custom cancel button label (default: 'Cancel').
+  final String? cancelLabel;
+
+  /// Optional: Show percentage text (default: true)
+  final bool showPercentage;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Calculate percentage for display
+    final percentage = (progress.clamp(0.0, 1.0) * 100).toStringAsFixed(0);
+
+    return Center(
+      child: Material(
+        elevation: 6,
+        borderRadius: BorderRadius.circular(16),
+        color: colorScheme.surface,
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.sizeOf(context).width * 0.7,
+            minWidth: 280,
+          ),
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 16,
+            children: [
+              // Title
+              Text(
+                title,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+
+              // Percentage text
+              if (showPercentage)
+                Text(
+                  '$percentage%',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+
+              // Progress indicator (uses global ProgressIndicatorThemeData)
+              LinearProgressIndicator(value: progress),
+
+              // Progress description
+              Text(
+                '$percentage% completed',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+
+              // Cancel button
+              if (onCancel != null) ...[
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: onCancel,
+                    child: Text(cancelLabel ?? 'Cancel'),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/download_progress_card.dart
+++ b/lib/widgets/download_progress_card.dart
@@ -1,15 +1,31 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import 'package:flutter/material.dart';
 
 /// A reusable, dialog-like card widget for displaying download/job progress.
-///
 class DownloadProgressCard extends StatelessWidget {
-
   const DownloadProgressCard({
-    required this.title, required this.progress, super.key,
+    required this.title,
+    required this.progress,
+    super.key,
     this.onCancel,
     this.cancelLabel,
     this.showPercentage = true,
   });
+
   /// Title displayed at the top of the progress card.
   final String title;
 


### PR DESCRIPTION
Moved the `Utility association types` Container to a card as `theme_data` already had theming support for Card.

<img height="600" alt="Screenshot_20260505_110907" src="https://github.com/user-attachments/assets/a2812db0-d6d2-461b-8606-00dcd6b82397" />

<img height="600" alt="Screenshot_20260505_110927" src="https://github.com/user-attachments/assets/b22a8e0b-b4b9-4946-bad2-9e5a869abd43" />
