### PR TITLE
Add install command to initialize script

### DIFF
--- a/tool/initialize.dart
+++ b/tool/initialize.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 
 void main(List<String> arguments) async {
   await runDart(['pub', 'upgrade']);
+  await runDart(['run', 'arcgis_maps', 'install']);
   await runDart([
     'run',
     'build_runner',


### PR DESCRIPTION
Currently we neither call install in the initialize.dart script nor have it listed in the readme.

We previously had it within the initialize.dart script so I've reverted that rather than add to the readme. We should add to `main` as the first priority to support those using the samples with the current release. I'll then cherry pick to `v.next`.