### PR TITLE
Add license placeholder

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,12 @@ void main() async {
   // const apiKey = ''; // Your API Key here.
   ArcGISEnvironment.apiKey = apiKey;
 
+  // (Optional) Supply a license key using the --dart-define-from-file command line argument.
+  const licenseKey = String.fromEnvironment('LICENSE_KEY');
+  if (licenseKey.isNotEmpty) {
+    ArcGISEnvironment.setLicenseUsingKey(licenseKey);
+  }
+
   WidgetsFlutterBinding.ensureInitialized();
 
   final prefs = await SharedPreferences.getInstance();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,8 +33,17 @@ void main() async {
 
   // (Optional) Supply a license key using the --dart-define-from-file command line argument.
   const licenseKey = String.fromEnvironment('LICENSE_KEY');
-  if (licenseKey.isNotEmpty) {
-    ArcGISEnvironment.setLicenseUsingKey(licenseKey);
+  const advancedEditingExtension = String.fromEnvironment(
+    'ADVANCED_EDITING_EXTENSION',
+  );
+  const analysisExtension = String.fromEnvironment('ANALYSIS_EXTENSION');
+  if (licenseKey.isNotEmpty &&
+      advancedEditingExtension.isNotEmpty &&
+      analysisExtension.isNotEmpty) {
+    ArcGISEnvironment.setLicenseUsingKey(
+      licenseKey,
+      extensions: [advancedEditingExtension, analysisExtension],
+    );
   }
 
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Makes it possible for us to set a license string on daily builds.

Makes it clear this is optional to developers to run the sample viewer.