### PR TITLE
Add mounted checks after async sample operations

### DIFF
--- a/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
+++ b/lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart
@@ -120,6 +120,7 @@ class _FindAddressWithReverseGeocodeState
       location: normalizedTapPoint as ArcGISPoint,
       parameters: reverseGeocodeParameters,
     );
+    if (!mounted) return;
     if (reverseGeocodeResult.isEmpty) return;
 
     // Get attributes from the first result and display a formatted address in a dialog.

--- a/lib/samples/identify_raster_cell/identify_raster_cell.dart
+++ b/lib/samples/identify_raster_cell/identify_raster_cell.dart
@@ -76,6 +76,8 @@ class _IdentifyRasterCellState extends State<IdentifyRasterCell>
       screenPoint: position,
       tolerance: 1,
     );
+    if (!mounted) return;
+
     // Get the identified raster cell.
     if (identifyResult.geoElements.isNotEmpty) {
       // Create a StringBuffer to display information to the user.


### PR DESCRIPTION
## Summary
- Add a `mounted` guard after `reverseGeocode` in the reverse geocode sample.
- Add a `mounted` guard after `identify` in the raster cell sample.
- Prevent UI/state work from running if the widget is disposed while awaiting async operations.

## Changes
- `lib/samples/find_address_with_reverse_geocode/find_address_with_reverse_geocode.dart`
  - Add `if (!mounted) return;` immediately after the async reverse geocode call.
- `lib/samples/identify_raster_cell/identify_raster_cell.dart`
  - Add `if (!mounted) return;` immediately after the async identify call.

## Why
These samples perform async work and then interact with UI/state. If the widget is disposed before completion, subsequent operations can run against an invalid context. The `mounted` checks make this flow lifecycle-safe and silence related analyzer warnings.

## Testing
- Analyzer warning path verified by code inspection.
- No behavioral change expected while widgets are mounted.
- When a view is disposed mid-await, the callback now exits early.