### PR TITLE
Add UI to Sample Viewer to set an API key as a user

### DIFF
--- a/lib/common/api_key_manager.dart
+++ b/lib/common/api_key_manager.dart
@@ -20,13 +20,19 @@ import 'package:flutter/foundation.dart';
 class ApiKeyManager {
   ApiKeyManager._();
 
-  // The API key provided at build time using `--dart-define`.
-  static const _buildTimeApiKey = String.fromEnvironment('API_KEY');
+  // The API key provided by the app at startup.
+  static var _buildTimeApiKey = '';
 
   // Whether the active API key is a session-only override.
   static final isUsingOverride = ValueNotifier(false);
 
-  // Applies the build-time API key and clears any session-only override state.
+  // Stores and applies the default API key for the app session.
+  static void setBuildTimeKey(String buildTimeKey) {
+    _buildTimeApiKey = buildTimeKey;
+    applyBuildTimeApiKey();
+  }
+
+  // Applies the stored build-time API key and clears any override state.
   static void applyBuildTimeApiKey() {
     ArcGISEnvironment.apiKey = _buildTimeApiKey;
     isUsingOverride.value = false;

--- a/lib/common/api_key_manager.dart
+++ b/lib/common/api_key_manager.dart
@@ -1,0 +1,46 @@
+//
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:arcgis_maps/arcgis_maps.dart';
+import 'package:flutter/foundation.dart';
+
+class ApiKeyManager {
+  ApiKeyManager._();
+
+  // The API key provided at build time using `--dart-define`.
+  static const _buildTimeApiKey = String.fromEnvironment('API_KEY');
+
+  // Whether the active API key is a session-only override.
+  static final isUsingOverride = ValueNotifier(false);
+
+  // Applies the build-time API key and clears any session-only override state.
+  static void applyBuildTimeApiKey() {
+    ArcGISEnvironment.apiKey = _buildTimeApiKey;
+    isUsingOverride.value = false;
+  }
+
+  // Applies a session-only API key override.
+  // Returns false when the entered key is empty after trimming pasted whitespace.
+  static bool applyOverride(String apiKey) {
+    final trimmedApiKey = apiKey.trim();
+    if (trimmedApiKey.isEmpty) return false;
+
+    ArcGISEnvironment.apiKey = trimmedApiKey;
+    isUsingOverride.value = true;
+
+    return true;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@
 
 import 'dart:convert';
 import 'package:arcgis_maps/arcgis_maps.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/common/api_key_manager.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/theme_data.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/router_config.dart';
@@ -25,11 +26,12 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
-  // Supply your apiKey using the --dart-define-from-file command line argument.
-  const apiKey = String.fromEnvironment('API_KEY');
-  // Alternatively, replace the above line with the following and hard-code your apiKey here:
-  // const apiKey = ''; // Your API Key here.
-  ArcGISEnvironment.apiKey = apiKey;
+  // Initialize Flutter before reading preferences and bundled sample metadata.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Use the build-time API key by default. The About screen can set a
+  // session-only override later without revealing the active key.
+  ApiKeyManager.applyBuildTimeApiKey();
 
   // (Optional) Supply a license key using the --dart-define-from-file command line argument.
   const licenseKey = String.fromEnvironment('LICENSE_KEY');
@@ -45,8 +47,6 @@ void main() async {
       extensions: [advancedEditingExtension, analysisExtension],
     );
   }
-
-  WidgetsFlutterBinding.ensureInitialized();
 
   final prefs = await SharedPreferences.getInstance();
   FavoriteRepository.instance.initialize(prefs);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,9 +29,11 @@ void main() async {
   // Initialize Flutter before reading preferences and bundled sample metadata.
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Use the build-time API key by default. The About screen can set a
-  // session-only override later without revealing the active key.
-  ApiKeyManager.applyBuildTimeApiKey();
+  // Supply your apiKey using the --dart-define-from-file command line argument.
+  const apiKey = String.fromEnvironment('API_KEY');
+  // Alternatively, replace the above line with the following and hard-code your apiKey here:
+  // const apiKey = ''; // Your API Key here.
+  ApiKeyManager.setBuildTimeKey(apiKey);
 
   // (Optional) Supply a license key using the --dart-define-from-file command line argument.
   const licenseKey = String.fromEnvironment('LICENSE_KEY');

--- a/lib/widgets/about_info.dart
+++ b/lib/widgets/about_info.dart
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import 'package:arcgis_maps_sdk_flutter_samples/common/api_key_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -27,6 +28,7 @@ class AboutInfo extends StatefulWidget {
 }
 
 class _AboutInfoState extends State<AboutInfo> {
+  // Package metadata shown in the About sheet.
   final _packageInfoFuture = PackageInfo.fromPlatform();
 
   @override
@@ -58,6 +60,116 @@ class _AboutInfoState extends State<AboutInfo> {
               },
             ),
           ],
+        ),
+        ValueListenableBuilder(
+          valueListenable: ApiKeyManager.isUsingOverride,
+          builder: (context, isUsingOverride, child) {
+            return ListTile(
+              contentPadding: .zero,
+              leading: const Icon(Icons.key),
+              title: const Text('API key'),
+              subtitle: Text(
+                isUsingOverride ? 'Custom key set' : 'Build-time key',
+              ),
+              trailing: FilledButton(
+                onPressed: () => _showApiKeyDialog(context, isUsingOverride),
+                child: const Text('Set'),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  // Shows the API key override dialog and reports the result.
+  Future<void> _showApiKeyDialog(
+    BuildContext context,
+    bool isUsingOverride,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+
+    final result = await showDialog<_ApiKeyDialogResult>(
+      context: context,
+      builder: (context) => _ApiKeyDialog(isUsingOverride: isUsingOverride),
+    );
+
+    if (!context.mounted) return;
+
+    switch (result) {
+      case _ApiKeyDialogResult.overrideApplied:
+        messenger.showSnackBar(
+          const SnackBar(content: Text('API key override applied.')),
+        );
+      case _ApiKeyDialogResult.buildTimeKeyApplied:
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Using build-time API key.')),
+        );
+      case null:
+        break;
+    }
+  }
+}
+
+// The action completed from the API key dialog.
+enum _ApiKeyDialogResult { overrideApplied, buildTimeKeyApplied }
+
+// Dialog for setting or clearing the session-only API key override.
+class _ApiKeyDialog extends StatefulWidget {
+  const _ApiKeyDialog({required this.isUsingOverride});
+
+  // Whether a session-only API key override is currently active.
+  final bool isUsingOverride;
+
+  @override
+  State<_ApiKeyDialog> createState() => _ApiKeyDialogState();
+}
+
+class _ApiKeyDialogState extends State<_ApiKeyDialog> {
+  // Holds new key input without pre-filling or revealing the active key.
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Set API key'),
+      content: TextField(
+        controller: _controller,
+        // Always start empty and obscure input so the active key is never shown.
+        obscureText: true,
+        enableSuggestions: false,
+        autocorrect: false,
+        decoration: const InputDecoration(
+          labelText: 'API key',
+          hintText: 'Enter API key',
+        ),
+      ),
+      actions: [
+        if (widget.isUsingOverride)
+          TextButton(
+            onPressed: () {
+              ApiKeyManager.applyBuildTimeApiKey();
+              Navigator.pop(context, _ApiKeyDialogResult.buildTimeKeyApplied);
+            },
+            child: const Text('Use build-time key'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            if (!ApiKeyManager.applyOverride(_controller.text)) return;
+
+            Navigator.pop(context, _ApiKeyDialogResult.overrideApplied);
+          },
+          child: const Text('Set'),
         ),
       ],
     );


### PR DESCRIPTION
There’s intentionally no validation or verification of the API key here. The implementation assumes users provide a valid key, which is consistent with the existing Qt implementation. The only processing we apply is trimming leading/trailing whitespace to avoid issues caused by accidental spaces.

By default the API key is not persisted, the implementation is a session-only override.