### PR TITLE
Fix offline ZIP path handling for filenames with multiple periods.

### DIFF
--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -261,43 +261,70 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
     }
   }
 
-  // Get the file paths of the downloaded resources.
+  /// Returns the expected file paths of the downloaded resources after extraction.
+  ///
+  /// For ZIP resources, returns the path to the resource inside the extracted directory.
+  /// For non-ZIP resources, returns the direct file path.
   Future<List<String>> _getDownloadFilePaths() async {
     final appDir = await getApplicationDocumentsDirectory();
     return widget.resources.map((res) {
-      final downloadablePrefix = res.downloadable.split('.').first;
-      if (res.downloadable.toLowerCase().endsWith('.zip')) {
+      // Remove only the trailing extension (e.g., .zip, .vtpk).
+      final downloadableWithoutExt = path.withoutExtension(res.downloadable);
+
+      // Check if this is a ZIP file (using both metadata flag and filename).
+      final isZip = res.downloadable.toLowerCase().endsWith('.zip');
+
+      if (isZip) {
+        // For ZIP files, the structure is:
+        // <appDir>/<downloadableWithoutExt>/<resource>
         return res.resource != null
-            ? path.join(appDir.absolute.path, downloadablePrefix, res.resource)
-            : path.join(appDir.absolute.path, downloadablePrefix);
+            ? path.join(
+                appDir.absolute.path,
+                downloadableWithoutExt,
+                res.resource,
+              )
+            : path.join(appDir.absolute.path, downloadableWithoutExt);
       } else {
+        // For non-ZIP files, the file is stored directly.
         return path.join(appDir.absolute.path, res.downloadable);
       }
     }).toList();
   }
 
-  // Clean up partially downloaded files.
+  /// Cleans up partially downloaded files and extracted directories.
+  ///
+  /// Deletes:
+  /// - The downloaded file (ZIP or non-ZIP)
+  /// - The extracted directory (for ZIP files only)
   Future<void> _cleanupFiles() async {
     final appDir = await getApplicationDocumentsDirectory();
     for (final resource in widget.resources) {
       try {
-        final file = File(
+        // Delete the downloaded file.
+        final downloadedFile = File(
           path.join(appDir.absolute.path, resource.downloadable),
         );
-        if (file.existsSync()) {
-          file.deleteSync();
+        if (downloadedFile.existsSync()) {
+          downloadedFile.deleteSync();
         }
-        final dir = Directory(
-          path.join(
-            appDir.absolute.path,
-            resource.downloadable.split('.').first,
-          ),
-        );
-        if (dir.existsSync()) {
-          dir.deleteSync(recursive: true);
+
+        // For ZIP files, also delete the extracted directory.
+        final isZip = resource.downloadable.toLowerCase().endsWith('.zip');
+        if (isZip) {
+          // Use path.withoutExtension to match the extraction directory naming.
+          final extractionDirName = path.withoutExtension(
+            resource.downloadable,
+          );
+          final extractionDir = Directory(
+            path.join(appDir.absolute.path, extractionDirName),
+          );
+          if (extractionDir.existsSync()) {
+            extractionDir.deleteSync(recursive: true);
+          }
         }
-      } on FileSystemException {
-        // Ignore errors during cleanup.
+      } on FileSystemException catch (e) {
+        // Ignore errors during cleanup - file may not exist or may be locked.
+        debugPrint('Cleanup warning: ${e.message}');
       }
     }
   }


### PR DESCRIPTION
### Description

Samples using offline ZIP files with multiple periods in the filename (e.g. `ContingentValuesBirdNests.geodatabase.zip`) were crashing with `File not found`.

The issue was caused by using `.split('.').first` to derive extracted folder names, which dropped everything after the first period and did not match the actual extraction directory.

This PR fixes the mismatch by replacing the fragile string split logic with `path.withoutExtension()` in:

* `_getDownloadFilePaths()`
* `_cleanupFiles()`
* Additional comments to describe the function and renamed variables to better reflect their characteristic.

**This ensures only the final `.zip` extension is removed, preserving intermediate periods and keeping path resolution and cleanup consistent with extraction logic.**
