### PR TITLE
Create a basic AGENTS.md and a skill to create a new sample

### DIFF
--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: create-new-sample
+description: Stub in a new sample and implement it.
+---
+# Inputs
+- Sample name
+- Sample category
+- Design doc path from `../common-samples/designs/`
+
+# Expected outputs
+- New sample directory: `lib/samples/<sample_name_snake_case>/`
+- Sample implementation file(s)
+- Sample `README.md`
+- Any required registration updates so the sample appears in the
+  app
+
+If the expected directory is not created, report an error and
+stop the process.
+
+# Workflow
+
+## 1. Determine the Sample name, category, and design doc path
+
+If the user did not specify Sample name and category, prompt the
+user to input them. The Sample name should be in Title Case
+(e.g., "Analyze Hotspots") and the category should be one of
+the existing categories (e.g., "Analysis", "Visualization",
+etc.).
+
+The design doc must be available in `../common-samples/designs/`.
+If it cannot be located, or if the Sample name or category does not
+match, report an error and stop the process.
+
+## 2. Run the `generate_new_sample.dart` script
+
+Run `dart tool/generate_new_sample.dart` passing the Sample name
+and the Sample category as arguments. For example:
+```bash
+dart tool/generate_new_sample.dart "Analyze Hotspots" "Analysis"
+```
+
+If the script returns a non-zero exit code, report the error and
+stop the process.
+
+## 3. Locate other implementations of the sample
+
+Check the Swift and Kotlin samples repos (as described in
+AGENTS.md) for existing implementations of the sample. If found,
+note their locations for reference during implementation.
+
+## 4. Implement the sample
+
+Use the generated sample files as a starting point. Refer to the
+design doc and any existing implementations in other languages to
+implement the sample in Dart/Flutter. Follow existing patterns and
+conventions used in other samples.
+
+## 5. Run the initialize step
+
+After implementing the sample, run `dart tool/initialize.dart` to
+regenerate any affected code and update the project state.
+
+## 6. Check for analyze issues
+
+Run `flutter analyze` to check for any issues in the code. Address
+any issues that are found.
+

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -2,13 +2,20 @@
 name: create-new-sample
 description: Scaffolds, implements, and validates a new Flutter sample based on existing designs.
 ---
-# Inputs
-- sample_name: The name of the sample in Title Case (e.g., "Analyze Hotspots").
-- sample_category: The category of the sample (e.g., "Analysis", "Visualization").
-- design_directory: The directory containing the design files for the sample, located in `../common-samples/designs/`.
-- documentation_directory: Path to the API docs at `../flutter/arcgis_maps/doc/api/`.
 
-# Expected outputs
+# Inputs
+
+- sample_name: The name of the sample in sentence case (e.g., "Analyze
+	hotspots").
+- sample_category: The category of the sample (e.g., "Analysis",
+	"Visualization").
+- design_directory: The directory containing the design files for the sample,
+	located in `../common-samples/designs/`.
+- documentation_directory: Path to the API docs at
+	`../flutter/arcgis_maps/doc/api/`.
+
+# Expected Outputs
+
 - New sample directory: `lib/samples/<sample_name_snake_case>/`
 - Sample implementation file(s)
 - Sample `README.md`
@@ -19,17 +26,25 @@ description: Scaffolds, implements, and validates a new Flutter sample based on 
 
 ## Phase 1: Strict Validation & Setup
 
-1. Validate that the user provided `sample_name`. If not provided, prompt the user to input it. Ensure it is in sentence case. If the input is malformed, halt execution.
+1. Validate that the user provided `sample_name`. If not provided, prompt the
+	user to input it. Ensure it is in sentence case. If the input is malformed,
+	halt execution.
 2. Verify the `design_directory` exists. If not found, halt execution.
-3. Validate that the user provided `sample_category` or that `sample_category` can be determined from the `implementation-details.md` file in the design directory. If it cannot be determined, halt execution.
-4. Verify the `documentation_directory` exists and contains API reference files. If not found, halt execution.
+3. Validate that the user provided `sample_category` or that
+	`sample_category` can be determined from the
+	`implementation-details.md` file in the design directory. If it cannot be
+	determined, halt execution.
+4. Verify the `documentation_directory` exists and contains API reference
+	files. If not found, halt execution.
 
 ## Phase 2: Scaffolding
 
 Execute the scaffolding script:
+
 ```bash
 dart tool/generate_new_sample.dart "<sample_name>" "<sample_category>"
 ```
+
 If the script returns a non-zero exit code, halt execution and report the console error.
 
 ## Phase 3: Targeted Context Gathering
@@ -38,7 +53,9 @@ Read the `implementation-details.md` file located within the provided `design_di
 
 Locate the corresponding Swift and Kotlin implementations by querying the repos defined in `AGENTS.md`.
 
-Read only the core controller/view files from those cross-platform samples to identify the primary ArcGIS mapping classes and architectural patterns required.
+Read only the core controller/view files from those cross-platform samples to
+identify the primary ArcGIS mapping classes and architectural patterns
+required.
 
 ## Phase 4: Deterministic Implementation
 
@@ -46,22 +63,35 @@ Use the scaffolded Dart files as your foundation.
 
 Translate the logic identified in Phase 3 into Dart/Flutter.
 
-API Reference Protocol: Do not attempt to ingest the entire `documentation_directory`. Instead, cross-reference the specific ArcGIS classes identified in Phase 3 by reading only their corresponding Dart documentation files within `../flutter/arcgis_maps/doc/api/`.
+API Reference Protocol: Do not attempt to ingest the entire
+`documentation_directory`. Instead, cross-reference the specific ArcGIS
+classes identified in Phase 3 by reading only their corresponding Dart
+documentation files within `../flutter/arcgis_maps/doc/api/`.
 
-If a specific API file is missing, leave a `// TODO: Implement <Feature> - API doc missing` comment in the Dart code and continue.
+If a specific API file is missing, leave a
+`// TODO: Implement <Feature> - API doc missing` comment in the Dart code and
+continue.
 
 ## Phase 5: State Synchronization
 
 Execute the initialization script to regenerate affected code:
+
 ```bash
 dart tool/initialize.dart
 ```
+
 If this fails, do not attempt to fix the generator script. Halt and report the failure.
 
-## Phase 6: Validation & Structured Reporting
+## Phase 6: Validation and Structured Reporting
 
 Run `flutter analyze` against the newly created sample directory.
 
-Circuit Breaker: Attempt to resolve any detected analysis issues. You are permitted a maximum of 3 iterative fix attempts. If issues persist after 3 attempts, cease fixing.
+Circuit Breaker: Attempt to resolve any detected analysis issues. You are
+permitted a maximum of 3 iterative fix attempts. If issues persist after 3
+attempts, cease fixing.
 
-Generate a file named `AGENT_REPORT.md` in the new sample directory. This file must contain a markdown table reporting the pass, fail, or skip status of the following stages: Scaffolding, Implementation, Initialization, and Analysis. Include a brief notes column for any captured console errors or missing API files.
+Generate a file named `AGENT_REPORT.md` in the new sample directory. This file
+must contain a markdown table reporting the pass, fail, or skip status of the
+following stages: Scaffolding, Implementation, Initialization, and Analysis.
+Include a brief notes column for any captured console errors or missing API
+files.

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -5,7 +5,7 @@ description: Stub in a new sample and implement it.
 # Inputs
 - Sample name
 - Sample category
-- Design doc path from `../common-samples/designs/`
+- Design directory from `../common-samples/designs/`
 
 # Expected outputs
 - New sample directory: `lib/samples/<sample_name_snake_case>/`
@@ -14,12 +14,9 @@ description: Stub in a new sample and implement it.
 - Any required registration updates so the sample appears in the
   app
 
-If the expected directory is not created, report an error and
-stop the process.
-
 # Workflow
 
-## 1. Determine the Sample name, category, and design doc path
+## 1. Determine the Sample name, category, and design directory
 
 If the user did not specify Sample name and category, prompt the
 user to input them. The Sample name should be in Title Case
@@ -27,9 +24,8 @@ user to input them. The Sample name should be in Title Case
 the existing categories (e.g., "Analysis", "Visualization",
 etc.).
 
-The design doc must be available in `../common-samples/designs/`.
-If it cannot be located, or if the Sample name or category does not
-match, report an error and stop the process.
+The design directory must be available in `../common-samples/designs/`.
+If it cannot be located, report an error and stop the process.
 
 ## 2. Run the `generate_new_sample.dart` script
 
@@ -51,9 +47,10 @@ note their locations for reference during implementation.
 ## 4. Implement the sample
 
 Use the generated sample files as a starting point. Refer to the
-design doc and any existing implementations in other languages to
-implement the sample in Dart/Flutter. Follow existing patterns and
-conventions used in other samples.
+`implementation-details.md` file in the design directory and any
+existing implementations in other languages to implement the
+sample in Dart/Flutter. Follow existing patterns and conventions
+used in other samples.
 
 ## 5. Run the initialize step
 

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -5,8 +5,8 @@ description: Scaffolds, implements, and validates a new Flutter sample based on 
 
 # Inputs
 
-- sample_name: The name of the sample in sentence case (e.g., "Analyze
-	hotspots").
+- sample_name: The name of the sample in TitleCase (e.g.,
+	"AnalyzeHotspots").
 - sample_category: The category of the sample (e.g., "Analysis",
 	"Visualization").
 - design_directory: The directory containing the design files for the sample,
@@ -27,8 +27,8 @@ description: Scaffolds, implements, and validates a new Flutter sample based on 
 ## Phase 1: Strict Validation & Setup
 
 1. Validate that the user provided `sample_name`. If not provided, prompt the
-	user to input it. Ensure it is in sentence case. If the input is malformed,
-	halt execution.
+	user to input it. If necessary, convert it to TitleCase. If the input is
+	malformed, halt execution.
 2. Verify the `design_directory` exists. If not found, halt execution.
 3. Validate that the user provided `sample_category` or that
 	`sample_category` can be determined from the
@@ -61,12 +61,13 @@ required.
 
 Use the scaffolded Dart files as your foundation.
 
-Translate the logic identified in Phase 3 into Dart/Flutter.
-
 API Reference Protocol: Do not attempt to ingest the entire
 `documentation_directory`. Instead, cross-reference the specific ArcGIS
 classes identified in Phase 3 by reading only their corresponding Dart
-documentation files within `../flutter/arcgis_maps/doc/api/`.
+documentation files within `../flutter/arcgis_maps/doc/api/`. Do not attempt
+to read from the `.pub-cache` directory.
+
+Translate the logic identified in Phase 3 into Dart/Flutter.
 
 If a specific API file is missing, leave a
 `// TODO: Implement <Feature> - API doc missing` comment in the Dart code and

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -6,6 +6,7 @@ description: Stub in a new sample and implement it.
 - Sample name
 - Sample category
 - Design directory from `../common-samples/designs/`
+- Documentation directory from `../flutter/arcgis_maps/doc/api/`
 
 # Expected outputs
 - New sample directory: `lib/samples/<sample_name_snake_case>/`
@@ -18,19 +19,19 @@ description: Stub in a new sample and implement it.
 
 ## 1. Determine the Sample name, category, and design directory
 
-If the user did not specify Sample name and category, prompt the
-user to input them. The Sample name should be in Title Case
-(e.g., "Analyze Hotspots") and the category should be one of
-the existing categories (e.g., "Analysis", "Visualization",
-etc.).
+If the user did not specify Sample name and category, prompt the user
+to input them. The Sample name should be in Title Case (e.g.,
+"Analyze Hotspots") and the category should be one of the existing
+categories (e.g., "Analysis", "Visualization", etc.).
 
-The design directory must be available in `../common-samples/designs/`.
-If it cannot be located, report an error and stop the process.
+The design directory must be available in
+`../common-samples/designs/`. If it cannot be located, report an
+error and stop the process.
 
 ## 2. Run the `generate_new_sample.dart` script
 
-Run `dart tool/generate_new_sample.dart` passing the Sample name
-and the Sample category as arguments. For example:
+Run `dart tool/generate_new_sample.dart` passing the Sample name and
+the Sample category as arguments. For example:
 ```bash
 dart tool/generate_new_sample.dart "Analyze Hotspots" "Analysis"
 ```
@@ -40,17 +41,26 @@ stop the process.
 
 ## 3. Locate other implementations of the sample
 
-Check the Swift and Kotlin samples repos (as described in
-AGENTS.md) for existing implementations of the sample. If found,
-note their locations for reference during implementation.
+Check the Swift and Kotlin samples repos (as described in AGENTS.md)
+for existing implementations of the sample. If found, note their
+locations for reference during implementation.
 
 ## 4. Implement the sample
 
 Use the generated sample files as a starting point. Refer to the
 `implementation-details.md` file in the design directory and any
-existing implementations in other languages to implement the
-sample in Dart/Flutter. Follow existing patterns and conventions
-used in other samples.
+existing implementations in other languages to implement the sample
+in Dart/Flutter.
+
+Refer to the API surface at `../flutter/arcgis_maps/doc/api/**` to
+determine the proper API calls and usage. These files were produced by
+running `dart doc` in the `arcgis_maps/` directory.
+
+If the required API reference is missing or invalid, report an error
+message specifying the issue but continue to implement as much of the
+sample as possible.
+
+Follow existing patterns and conventions used in other samples.
 
 ## 5. Run the initialize step
 
@@ -59,6 +69,6 @@ regenerate any affected code and update the project state.
 
 ## 6. Check for analyze issues
 
-Run `flutter analyze` to check for any issues in the code. Address
-any issues that are found.
+Run `flutter analyze` to check for any issues in the code. Address any
+issues that are found.
 

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -1,74 +1,67 @@
 ---
 name: create-new-sample
-description: Stub in a new sample and implement it.
+description: Scaffolds, implements, and validates a new Flutter sample based on existing designs.
 ---
 # Inputs
-- Sample name
-- Sample category
-- Design directory from `../common-samples/designs/`
-- Documentation directory from `../flutter/arcgis_maps/doc/api/`
+- sample_name: The name of the sample in Title Case (e.g., "Analyze Hotspots").
+- sample_category: The category of the sample (e.g., "Analysis", "Visualization").
+- design_directory: The directory containing the design files for the sample, located in `../common-samples/designs/`.
+- documentation_directory: Path to the API docs at `../flutter/arcgis_maps/doc/api/`.
 
 # Expected outputs
 - New sample directory: `lib/samples/<sample_name_snake_case>/`
 - Sample implementation file(s)
 - Sample `README.md`
-- Any required registration updates so the sample appears in the
-  app
+- Required registration updates so the sample appears in the app
+- `AGENT_REPORT.md` detailing execution status
 
-# Workflow
+# Agent Workflow
 
-## 1. Determine the Sample name, category, and design directory
+## Phase 1: Strict Validation & Setup
 
-If the user did not specify Sample name and category, prompt the user
-to input them. The Sample name should be in Title Case (e.g.,
-"Analyze Hotspots") and the category should be one of the existing
-categories (e.g., "Analysis", "Visualization", etc.).
+1. Validate that the user provided `sample_name`. If not provided, prompt the user to input it. Ensure it is in sentence case. If the input is malformed, halt execution.
+2. Verify the `design_directory` exists. If not found, halt execution.
+3. Validate that the user provided `sample_category` or that `sample_category` can be determined from the `implementation-details.md` file in the design directory. If it cannot be determined, halt execution.
+4. Verify the `documentation_directory` exists and contains API reference files. If not found, halt execution.
 
-The design directory must be available in
-`../common-samples/designs/`. If it cannot be located, report an
-error and stop the process.
+## Phase 2: Scaffolding
 
-## 2. Run the `generate_new_sample.dart` script
-
-Run `dart tool/generate_new_sample.dart` passing the Sample name and
-the Sample category as arguments. For example:
+Execute the scaffolding script:
 ```bash
-dart tool/generate_new_sample.dart "Analyze Hotspots" "Analysis"
+dart tool/generate_new_sample.dart "<sample_name>" "<sample_category>"
 ```
+If the script returns a non-zero exit code, halt execution and report the console error.
 
-If the script returns a non-zero exit code, report the error and
-stop the process.
+## Phase 3: Targeted Context Gathering
 
-## 3. Locate other implementations of the sample
+Read the `implementation-details.md` file located within the provided `design_directory`.
 
-Check the Swift and Kotlin samples repos (as described in AGENTS.md)
-for existing implementations of the sample. If found, note their
-locations for reference during implementation.
+Locate the corresponding Swift and Kotlin implementations by querying the repos defined in `AGENTS.md`.
 
-## 4. Implement the sample
+Read only the core controller/view files from those cross-platform samples to identify the primary ArcGIS mapping classes and architectural patterns required.
 
-Use the generated sample files as a starting point. Refer to the
-`implementation-details.md` file in the design directory and any
-existing implementations in other languages to implement the sample
-in Dart/Flutter.
+## Phase 4: Deterministic Implementation
 
-Refer to the API surface at `../flutter/arcgis_maps/doc/api/**` to
-determine the proper API calls and usage. These files were produced by
-running `dart doc` in the `arcgis_maps/` directory.
+Use the scaffolded Dart files as your foundation.
 
-If the required API reference is missing or invalid, report an error
-message specifying the issue but continue to implement as much of the
-sample as possible.
+Translate the logic identified in Phase 3 into Dart/Flutter.
 
-Follow existing patterns and conventions used in other samples.
+API Reference Protocol: Do not attempt to ingest the entire `documentation_directory`. Instead, cross-reference the specific ArcGIS classes identified in Phase 3 by reading only their corresponding Dart documentation files within `../flutter/arcgis_maps/doc/api/`.
 
-## 5. Run the initialize step
+If a specific API file is missing, leave a `// TODO: Implement <Feature> - API doc missing` comment in the Dart code and continue.
 
-After implementing the sample, run `dart tool/initialize.dart` to
-regenerate any affected code and update the project state.
+## Phase 5: State Synchronization
 
-## 6. Check for analyze issues
+Execute the initialization script to regenerate affected code:
+```bash
+dart tool/initialize.dart
+```
+If this fails, do not attempt to fix the generator script. Halt and report the failure.
 
-Run `flutter analyze` to check for any issues in the code. Address any
-issues that are found.
+## Phase 6: Validation & Structured Reporting
 
+Run `flutter analyze` against the newly created sample directory.
+
+Circuit Breaker: Attempt to resolve any detected analysis issues. You are permitted a maximum of 3 iterative fix attempts. If issues persist after 3 attempts, cease fixing.
+
+Generate a file named `AGENT_REPORT.md` in the new sample directory. This file must contain a markdown table reporting the pass, fail, or skip status of the following stages: Scaffolding, Implementation, Initialization, and Analysis. Include a brief notes column for any captured console errors or missing API files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,23 @@ Each sample has a design document in the `common-samples` repository, cloned to
 Design docs are stored in `../common-samples/designs/`. Each subdirectory
 represents one design and uses the sample name in CamelCase. The matching sample
 directory under `lib/samples/` uses snake_case.
+
+## Other implementation repos
+
+These designs are also implemented for other platforms. Each platform has its own
+repo. These implementations can be used as a basis for porting the design to
+Flutter. Known repos are:
+
+### Swift samples repo
+
+Git URL: https://github.com/Esri/arcgis-maps-sdk-swift-samples
+
+Samples are under the `Shared/Samples/` directory. Each subdirectory is one
+sample. The Sample name is in sentence case, such as "Analyze hotspots".
+
+### Kotlin samples repo
+
+Git URL: https://github.com/Esri/arcgis-maps-sdk-kotlin-samples
+
+Samples are under the `samples` directory. Each subdirectory is one sample.
+The Sample name is in lowercase with dashes, such as `analyze-hotspots`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Guide
+
+## Purpose
+
+Basic guidance for coding agents and contributors working in this repository.
+
+## Repository summary
+
+- **Project:** ArcGIS Maps SDK for Flutter samples application
+- **Main language:** Dart
+- **Framework:** Flutter
+- **Primary app code:** `lib/`
+
+## Key paths
+
+- `lib/samples/`: Individual sample implementations
+- `lib/common/`: Shared app and sample infrastructure
+- `lib/widgets/`: Reusable UI components
+- `assets/`: Sample data, images, and static resources
+- `tool/`: Utility scripts for generating and maintaining samples
+- `android/`, `ios/`: Platform host projects
+
+## Build workflow
+
+1. Run `dart tool/initialize.dart` to perform the special `arcgis_maps` install
+   step and run code generation.
+2. Build platforms with `flutter build apk` and `flutter build ios`.
+3. If `../flutter/arcgis_maps/test/env.json` exists, pass it to `flutter build`
+   using `--dart-define-from-file`.
+
+## Design repo
+
+Each sample has a design document in the `common-samples` repository, cloned to
+`../common-samples`.
+
+Design docs are stored in `../common-samples/designs/`. Each subdirectory
+represents one design and uses the sample name in CamelCase. The matching sample
+directory under `lib/samples/` uses snake_case.


### PR DESCRIPTION
- `AGENTS.md`: basic information about the repo that should be loaded into an agent's context window whenever working with this repo.
- `.agents/skills/create-new-sample/SKILL.md`: an agent skill to create a new sample. Inputs are the common-samples design, the arcgis_maps `dart doc` documentation, and the Kotlin/Swift implementations (if available). It runs the `generate_new_sample.dart` tool and then implements the sample on top of that stub file. It is most useful when either the Kotlin or Swift version of the sample is available to port, and possibly if the `implementation-details.md` file contains a full implementation (though it might be oriented toward a desktop interface). Otherwise there usually isn't enough info just from the `README.md` to reliably produce the complete sample.

There are still improvements to be made, but I wanted to get this much done and available to use.