### PR TITLE
Update the sample creation skill

### DIFF
--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -59,7 +59,9 @@ required.
 
 ## Phase 4: Deterministic Implementation
 
-Use the scaffolded Dart files as your foundation.
+Use the scaffolded Dart files as your foundation. If there are no interactive controls,
+remove the SafeArea widget from the scaffolded code. Use simple layouts and controls.
+Use styling inherited from the existing Theme.
 
 API Reference Protocol: Do not attempt to ingest the entire
 `documentation_directory`. Instead, cross-reference the specific ArcGIS
@@ -73,7 +75,17 @@ If a specific API file is missing, leave a
 `// TODO: Implement <Feature> - API doc missing` comment in the Dart code and
 continue.
 
-## Phase 5: State Synchronization
+## Phase 5: Add Tutorial-style Comments
+
+The purpose of comments in this sample is to provide the reader a tutorial-style
+explanation of how the API is being used.
+
+Add concise, imperative comments to each method and to each distinct block of code
+within a method.
+
+Ensure all comments are sentences ending with a period.
+
+## Phase 6: State Synchronization
 
 Execute the initialization script to regenerate affected code:
 
@@ -83,7 +95,7 @@ dart tool/initialize.dart
 
 If this fails, do not attempt to fix the generator script. Halt and report the failure.
 
-## Phase 6: Validation and Structured Reporting
+## Phase 7: Validation and Reporting
 
 Run `flutter analyze` against the newly created sample directory.
 
@@ -91,8 +103,5 @@ Circuit Breaker: Attempt to resolve any detected analysis issues. You are
 permitted a maximum of 3 iterative fix attempts. If issues persist after 3
 attempts, cease fixing.
 
-Generate a file named `AGENT_REPORT.md` in the new sample directory. This file
-must contain a markdown table reporting the pass, fail, or skip status of the
-following stages: Scaffolding, Implementation, Initialization, and Analysis.
-Include a brief notes column for any captured console errors or missing API
-files.
+Provide a brief summary of each stage, including any errors encountered and how they
+were resolved.

--- a/.agents/skills/create-new-sample/SKILL.md
+++ b/.agents/skills/create-new-sample/SKILL.md
@@ -6,13 +6,13 @@ description: Scaffolds, implements, and validates a new Flutter sample based on 
 # Inputs
 
 - sample_name: The name of the sample in TitleCase (e.g.,
-	"AnalyzeHotspots").
+  "AnalyzeHotspots").
 - sample_category: The category of the sample (e.g., "Analysis",
-	"Visualization").
+  "Visualization").
 - design_directory: The directory containing the design files for the sample,
-	located in `../common-samples/designs/`.
+  located in `../common-samples/designs/`.
 - documentation_directory: Path to the API docs at
-	`../flutter/arcgis_maps/doc/api/`.
+  `../flutter/arcgis_maps/doc/api/`.
 
 # Expected Outputs
 
@@ -27,15 +27,15 @@ description: Scaffolds, implements, and validates a new Flutter sample based on 
 ## Phase 1: Strict Validation & Setup
 
 1. Validate that the user provided `sample_name`. If not provided, prompt the
-	user to input it. If necessary, convert it to TitleCase. If the input is
-	malformed, halt execution.
+   user to input it. If necessary, convert it to TitleCase. If the input is
+   malformed, halt execution.
 2. Verify the `design_directory` exists. If not found, halt execution.
 3. Validate that the user provided `sample_category` or that
-	`sample_category` can be determined from the
-	`implementation-details.md` file in the design directory. If it cannot be
-	determined, halt execution.
+   `sample_category` can be determined from the
+   `implementation-details.md` file in the design directory. If it cannot be
+   determined, halt execution.
 4. Verify the `documentation_directory` exists and contains API reference
-	files. If not found, halt execution.
+   files. If not found, halt execution.
 
 ## Phase 2: Scaffolding
 
@@ -59,9 +59,9 @@ required.
 
 ## Phase 4: Deterministic Implementation
 
-Use the scaffolded Dart files as your foundation. If there are no interactive controls,
-remove the SafeArea widget from the scaffolded code. Use simple layouts and controls.
-Use styling inherited from the existing Theme.
+Use the scaffolded Dart files as your foundation. If there are no interactive
+controls, remove the SafeArea widget from the scaffolded code. Use simple
+layouts and controls. Use styling inherited from the existing Theme.
 
 API Reference Protocol: Do not attempt to ingest the entire
 `documentation_directory`. Instead, cross-reference the specific ArcGIS
@@ -77,11 +77,11 @@ continue.
 
 ## Phase 5: Add Tutorial-style Comments
 
-The purpose of comments in this sample is to provide the reader a tutorial-style
-explanation of how the API is being used.
+The purpose of comments in this sample is to provide the reader a
+tutorial-style explanation of how the API is being used.
 
-Add concise, imperative comments to each method and to each distinct block of code
-within a method.
+Add concise, imperative comments to each method and to each distinct block of
+code within a method.
 
 Ensure all comments are sentences ending with a period.
 
@@ -103,5 +103,5 @@ Circuit Breaker: Attempt to resolve any detected analysis issues. You are
 permitted a maximum of 3 iterative fix attempts. If issues persist after 3
 attempts, cease fixing.
 
-Provide a brief summary of each stage, including any errors encountered and how they
-were resolved.
+Provide a brief summary of each stage, including any errors encountered and how
+they were resolved.

--- a/tool/initialize.dart
+++ b/tool/initialize.dart
@@ -22,6 +22,7 @@ import 'dart:io';
 void main(List<String> arguments) async {
   await runDart(['pub', 'upgrade']);
   await runDart(['run', 'arcgis_maps', 'install']);
+  await runDart(['run', 'build_runner', 'clean']);
   await runDart([
     'run',
     'build_runner',


### PR DESCRIPTION
Update the sample creation skill to produce tutorial-style comments. Also added some instructions on removing the SafeArea if there are no controls and using simple layouts with the inherited Theme.

The `initialize.dart` script now runs `build_runner clean` before the `build_runner build` step to make sure the generated files are fully in sync when the AI re-runs it at the end.