### PR TITLE
enable android.nonFinalResIds

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator


### PR DESCRIPTION
Sample Viewer build started failing after the recent upgrades to Flutter 3.44 and AGP 9. The error message instructs us to enable `android.nonFinalResIds`. This is one of those settings that `flutter create` sets, and it varies based on which version of `flutter` you were using when you created the project. The modern way is to leave it unspecified so that it defaults to "true".