### PR TITLE
Update xml package to major version 7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,11 @@ dependencies:
   simple_html_css: ^5.0.0
   url_launcher: ^6.3.1
   webview_flutter: ^4.10.0
-  xml: ^6.6.1
+  xml: ^7.0.1
+
+dependency_overrides:
+  # simple_html_css 5.0.0 requires xml ^6.5.0, but we can force it to 7
+  xml: ^7.0.1
 
 dev_dependencies:
   build_runner: ^2.4.15


### PR DESCRIPTION
We updated `arcgis_maps` to use `xml` 7.0.1. That requires SampleViewer to also update to 7.0.1. Unfortunately our other dependency `simple_html_css` requires an older version, so we have to use a dependency override to get it to build.