### PR TITLE
Fix dark mode rendering for portal organization HTML description

### DIFF
--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -116,7 +116,36 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
             }
 
             // If the portal load succeeded, display the portal information.
-            final titleStyle = Theme.of(context).textTheme.titleMedium;
+            final theme = Theme.of(context);
+            final colorScheme = theme.colorScheme;
+            final titleStyle = theme.textTheme.titleMedium;
+            // simple_html_css applies black as its default text color, so provide
+            // theme-aware styles for dark mode and portal-authored HTML colors.
+            final htmlTextStyle = theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurface,
+            );
+            final htmlOverrideStyle = {
+              for (final tag in [
+                'body',
+                'p',
+                'div',
+                'span',
+                'ul',
+                'ol',
+                'li',
+                'h1',
+                'h2',
+                'h3',
+                'h4',
+                'h5',
+                'h6',
+              ])
+                tag: TextStyle(color: colorScheme.onSurface),
+              'a': TextStyle(
+                color: colorScheme.primary,
+                decoration: TextDecoration.underline,
+              ),
+            };
             return SingleChildScrollView(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -124,7 +153,7 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
                 children: [
                   Text(
                     '${_portal.user?.fullName} Profile',
-                    style: Theme.of(context).textTheme.titleLarge,
+                    style: theme.textTheme.titleLarge,
                   ),
                   if (_userThumbnail != null)
                     Image.memory(_userThumbnail!)
@@ -158,6 +187,8 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
                       text: HTML.toTextSpan(
                         context,
                         _portal.portalInfo?.organizationDescription ?? '',
+                        defaultTextStyle: htmlTextStyle,
+                        overrideStyle: htmlOverrideStyle,
                       ),
                     ),
                   ),

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -121,9 +121,9 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
             final titleStyle = theme.textTheme.titleMedium;
             // simple_html_css applies black as its default text color, so provide
             // theme-aware styles for dark mode and portal-authored HTML colors.
-            final htmlTextStyle = theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurface,
-            );
+final htmlTextStyle = DefaultTextStyle.of(context).style.copyWith(
+  color: colorScheme.onSurface,
+);
             final htmlOverrideStyle = {
               for (final tag in [
                 'body',

--- a/lib/samples/show_portal_user_info/show_portal_user_info.dart
+++ b/lib/samples/show_portal_user_info/show_portal_user_info.dart
@@ -24,12 +24,15 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
     clientId: 'T0A3SudETrIQndd2',
     redirectUri: Uri.parse('my-ags-flutter-app://auth'),
   );
+
   // Create a Portal that requires authentication.
   final _portal = Portal.arcGISOnline(
     connection: PortalConnection.authenticated,
   );
+
   // Create a Future that tracks the loading of the portal.
   Future<void>? _portalLoadFuture;
+
   // Create variables to store the user and organization thumbnails.
   Uint8List? _userThumbnail;
   Uint8List? _organizationThumbnail;
@@ -121,11 +124,11 @@ class _ShowPortalUserInfoState extends State<ShowPortalUserInfo>
             final titleStyle = theme.textTheme.titleMedium;
             // simple_html_css applies black as its default text color, so provide
             // theme-aware styles for dark mode and portal-authored HTML colors.
-final htmlTextStyle = DefaultTextStyle.of(context).style.copyWith(
-  color: colorScheme.onSurface,
-);
+            final htmlTextStyle = DefaultTextStyle.of(
+              context,
+            ).style.copyWith(color: colorScheme.onSurface);
             final htmlOverrideStyle = {
-              for (final tag in [
+              for (final tag in const [
                 'body',
                 'p',
                 'div',


### PR DESCRIPTION
Fixes the `Show portal user info` sample so the organization `Description` field remains readable in dark mode.
<div style="display: flex; gap: 10px;">
  <img height="600" alt="portal_light" src="https://github.com/user-attachments/assets/367767a6-cb6e-47a4-b8ad-ed657c4e2f51" />
  <img height="600" alt="portal_dark" src="https://github.com/user-attachments/assets/57676d20-e550-412c-849f-8912729e29a4" />
</div>