### PR TITLE
Support Android 17

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.esri.arcgis_maps_sdk_flutter_samples"
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = "28.2.13676358"
 
     compileOptions {


### PR DESCRIPTION
### Summary

Bumps the Android compile SDK to 37 so the Flutter samples app supports Android 17.
