### PR TITLE
Refactor all banners to a single theme-aware banner widget

### DIFF
--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -20,6 +20,7 @@ export 'dialogs.dart';
 export 'download_util.dart';
 export 'feature_popup_view.dart';
 export 'loading_indicator.dart';
+export 'map_banner.dart';
 export 'sample_state_support.dart';
 export 'swatch_image.dart';
 export 'theme_data.dart';

--- a/lib/common/map_banner.dart
+++ b/lib/common/map_banner.dart
@@ -1,0 +1,51 @@
+//
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'package:flutter/material.dart';
+
+class MapBanner extends StatelessWidget {
+  const MapBanner({required this.text, super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      left: false,
+      right: false,
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.all(10),
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+          child: Row(
+            mainAxisAlignment: .center,
+            children: [
+              Expanded(
+                child: Text(
+                  text,
+                  textAlign: .center,
+                  style: Theme.of(context).textTheme.labelMedium,
+                  maxLines: 4,
+                  overflow: .ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/map_banner.dart
+++ b/lib/common/map_banner.dart
@@ -29,7 +29,7 @@ class MapBanner extends StatelessWidget {
       child: IgnorePointer(
         child: Container(
           padding: const EdgeInsets.all(10),
-          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+          color: ColorScheme.of(context).surface.withValues(alpha: 0.7),
           child: Row(
             mainAxisAlignment: .center,
             children: [
@@ -37,7 +37,7 @@ class MapBanner extends StatelessWidget {
                 child: Text(
                   text,
                   textAlign: .center,
-                  style: Theme.of(context).textTheme.labelMedium,
+                  style: TextTheme.of(context).labelMedium,
                   maxLines: 4,
                   overflow: .ellipsis,
                 ),

--- a/lib/common/theme_data.dart
+++ b/lib/common/theme_data.dart
@@ -127,13 +127,5 @@ final sampleViewerLightTheme = _buildTheme(lightColorScheme);
 final sampleViewerDarkTheme = _buildTheme(darkColorScheme);
 
 extension CustomTextTheme on TextTheme {
-  TextStyle get customLabelStyle =>
-      const TextStyle(fontSize: 18, fontWeight: .bold, color: Colors.white);
-
-  TextStyle get categoryCardLabelStyle =>
-      const TextStyle(fontSize: 16, fontWeight: .bold, color: Colors.white);
-
   TextStyle get customErrorStyle => const TextStyle(color: Colors.red);
-
-  TextStyle get customWhiteStyle => const TextStyle(color: Colors.white);
 }

--- a/lib/samples/add_dynamic_entity_layer/add_dynamic_entity_layer.dart
+++ b/lib/samples/add_dynamic_entity_layer/add_dynamic_entity_layer.dart
@@ -114,37 +114,13 @@ class _AddDynamicEntityLayerState extends State<AddDynamicEntityLayer>
             LoadingIndicator(visible: !_ready),
             // Display a banner with the current status at the top.
             if (_streamService != null)
-              SafeArea(
-                child: IgnorePointer(
-                  child: Container(
-                    padding: const EdgeInsets.all(10),
-                    color: Colors.black.withValues(alpha: 0.7),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: StreamBuilder<ConnectionStatus>(
-                            stream: _streamService!.onConnectionStatusChanged,
-                            initialData: _streamService!.connectionStatus,
-                            builder: (context, snapshot) {
-                              final status =
-                                  snapshot.data ??
-                                  ConnectionStatus.disconnected;
-                              return Text(
-                                'Status: ${status.label}',
-                                softWrap: true,
-                                textAlign: TextAlign.center,
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.customWhiteStyle,
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+              StreamBuilder(
+                stream: _streamService!.onConnectionStatusChanged,
+                initialData: _streamService!.connectionStatus,
+                builder: (context, snapshot) {
+                  final status = snapshot.data ?? .disconnected;
+                  return MapBanner(text: 'Status: ${status.label}');
+                },
               ),
           ],
         ),

--- a/lib/samples/create_buffers_around_points/create_buffers_around_points.dart
+++ b/lib/samples/create_buffers_around_points/create_buffers_around_points.dart
@@ -111,24 +111,7 @@ class _CreateBuffersAroundPointsState extends State<CreateBuffersAroundPoints>
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),
             // Display a banner with instructions at the top.
-            SafeArea(
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        _status.label,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.labelMedium,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+            MapBanner(text: _status.label),
           ],
         ),
       ),

--- a/lib/samples/display_content_of_utility_network_container/display_content_of_utility_network_container.dart
+++ b/lib/samples/display_content_of_utility_network_container/display_content_of_utility_network_container.dart
@@ -103,20 +103,7 @@ class _DisplayContentOfUtilityNetworkContainerState
                 // Add a banner to show the results of the identify operation.
                 Visibility(
                   visible: _message.isNotEmpty,
-                  child: Container(
-                    padding: const EdgeInsets.all(5),
-                    color: Colors.grey[400],
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          _message,
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.labelMedium,
-                        ),
-                      ],
-                    ),
-                  ),
+                  child: MapBanner(text: _message),
                 ),
                 Expanded(
                   // Add a map view to the widget tree and set a controller.

--- a/lib/samples/download_preplanned_map_area/download_preplanned_map_area.dart
+++ b/lib/samples/download_preplanned_map_area/download_preplanned_map_area.dart
@@ -87,20 +87,7 @@ class _DownloadPreplannedMapAreaState extends State<DownloadPreplannedMapArea>
               ],
             ),
             // Display the name of the current map.
-            Container(
-              padding: const EdgeInsets.all(10),
-              color: Colors.black.withValues(alpha: 0.7),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    _title,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.customWhiteStyle,
-                  ),
-                ],
-              ),
-            ),
+            MapBanner(text: _title),
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),
           ],

--- a/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
+++ b/lib/samples/edit_with_branch_versioning/edit_with_branch_versioning.dart
@@ -87,28 +87,11 @@ class _EditWithBranchVersioningState extends State<EditWithBranchVersioning>
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),
             // Display a banner with the current version at the top.
-            SafeArea(
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      ValueListenableBuilder(
-                        valueListenable: _model.currentVersionNameNotifier,
-                        builder: (context, currentVersionName, child) {
-                          return Text(
-                            'Version: $currentVersionName',
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.labelMedium,
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+            ValueListenableBuilder(
+              valueListenable: _model.currentVersionNameNotifier,
+              builder: (context, currentVersionName, child) {
+                return MapBanner(text: 'Version: $currentVersionName');
+              },
             ),
           ],
         ),

--- a/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
+++ b/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
@@ -207,26 +207,9 @@ class _FindRouteInMapState extends State<FindRouteInMap>
               ],
             ),
             // Add a banner to show the results of the identify operation.
-            SafeArea(
-              child: IgnorePointer(
-                child: Visibility(
-                  visible: _message.isNotEmpty,
-                  child: Container(
-                    padding: const EdgeInsets.all(10),
-                    color: Colors.black.withValues(alpha: 0.7),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          _message,
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.customWhiteStyle,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
+            Visibility(
+              visible: _message.isNotEmpty,
+              child: MapBanner(text: _message),
             ),
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),

--- a/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
+++ b/lib/samples/identify_features_in_wms_layer/identify_features_in_wms_layer.dart
@@ -40,47 +40,27 @@ class _IdentifyFeaturesInWmsLayerState extends State<IdentifyFeaturesInWmsLayer>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        top: false,
-        left: false,
-        right: false,
-        child: Stack(
-          children: [
-            Column(
-              children: [
-                Expanded(
-                  // Add a map view to the widget tree and set a controller.
-                  child: ArcGISMapView(
-                    controllerProvider: () => _mapViewController,
-                    onMapViewReady: onMapViewReady,
-                    onTap: onTap,
-                  ),
-                ),
-              ],
-            ),
-            // Display a banner with instructions.
-            SafeArea(
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: const Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        'Tap on the map to identify features in the WMS layer.',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(color: Colors.black),
-                      ),
-                    ],
-                  ),
+      body: Stack(
+        children: [
+          Column(
+            children: [
+              Expanded(
+                // Add a map view to the widget tree and set a controller.
+                child: ArcGISMapView(
+                  controllerProvider: () => _mapViewController,
+                  onMapViewReady: onMapViewReady,
+                  onTap: onTap,
                 ),
               ),
-            ),
-            // Display a progress indicator and prevent interaction until state is ready.
-            LoadingIndicator(visible: !_ready),
-          ],
-        ),
+            ],
+          ),
+          // Display a banner with instructions.
+          const MapBanner(
+            text: 'Tap on the map to identify features in the WMS layer.',
+          ),
+          // Display a progress indicator and prevent interaction until state is ready.
+          LoadingIndicator(visible: !_ready),
+        ],
       ),
     );
   }

--- a/lib/samples/identify_layer_features/identify_layer_features.dart
+++ b/lib/samples/identify_layer_features/identify_layer_features.dart
@@ -46,26 +46,9 @@ class _IdentifyLayerFeaturesState extends State<IdentifyLayerFeatures>
             onTap: onTap,
           ),
           // Add a banner to show the results of the identify operation.
-          SafeArea(
-            child: IgnorePointer(
-              child: Visibility(
-                visible: _message.isNotEmpty,
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.black.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        _message,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.customWhiteStyle,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+          Visibility(
+            visible: _message.isNotEmpty,
+            child: MapBanner(text: _message),
           ),
           // Display a progress indicator and prevent interaction until state is ready.
           LoadingIndicator(visible: !_ready),

--- a/lib/samples/measure_distance_in_scene/measure_distance_in_scene.dart
+++ b/lib/samples/measure_distance_in_scene/measure_distance_in_scene.dart
@@ -123,26 +123,7 @@ class _MeasureDistanceInSceneState extends State<MeasureDistanceInScene>
               ],
             ),
             // Display a banner with instructions at the top.
-            SafeArea(
-              left: false,
-              right: false,
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        _measurementState.instructions,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.labelMedium,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+            MapBanner(text: _measurementState.instructions),
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),
           ],

--- a/lib/samples/navigate_route/navigate_route.dart
+++ b/lib/samples/navigate_route/navigate_route.dart
@@ -175,31 +175,11 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
             // Display a progress indicator and prevent interaction until state is ready.
             LoadingIndicator(visible: !_ready),
             // Display a banner with the current status at the top.
-            SafeArea(
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Expanded(
-                        child: ValueListenableBuilder(
-                          valueListenable: _statusTextNotifier,
-                          builder: (context, statusText, child) {
-                            return Text(
-                              statusText,
-                              softWrap: true,
-                              textAlign: TextAlign.center,
-                              style: Theme.of(context).textTheme.labelMedium,
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+            ValueListenableBuilder(
+              valueListenable: _statusTextNotifier,
+              builder: (context, statusText, child) {
+                return MapBanner(text: statusText);
+              },
             ),
           ],
         ),
@@ -431,10 +411,9 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
     );
     _statusTextNotifier.value =
         '''
-  Distance remaining: ${status.routeProgress.remainingDistance.displayText} ${status.routeProgress.remainingDistance.displayTextUnits.abbreviation}
-  Time remaining: $formattedTime
-  Next direction: ${_directionsList[status.currentManeuverIndex + 1].directionText}
-  ''';
+Distance remaining: ${status.routeProgress.remainingDistance.displayText} ${status.routeProgress.remainingDistance.displayTextUnits.abbreviation}
+Time remaining: $formattedTime
+Next direction: ${_directionsList[status.currentManeuverIndex + 1].directionText}''';
   }
 
   void recenter() {

--- a/lib/samples/run_valve_isolation_trace/run_valve_isolation_trace.dart
+++ b/lib/samples/run_valve_isolation_trace/run_valve_isolation_trace.dart
@@ -135,25 +135,7 @@ class _RunValveIsolationTraceState extends State<RunValveIsolationTrace>
               text: _loading ? _statusMessage : '',
             ),
             // Display a banner with instructions at the top.
-            IgnorePointer(
-              child: Container(
-                padding: const EdgeInsets.all(5),
-                color: Colors.white.withValues(alpha: 0.7),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        _statusMessage ?? '',
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.labelMedium,
-                        maxLines: 4,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            MapBanner(text: _statusMessage ?? ''),
           ],
         ),
       ),

--- a/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/show_exploratory_viewshed_from_geoelement_in_scene.dart
+++ b/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/show_exploratory_viewshed_from_geoelement_in_scene.dart
@@ -49,37 +49,21 @@ class _ShowExploratoryViewshedFromGeoelementInSceneState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        top: false,
-        left: false,
-        right: false,
-        child: Stack(
-          children: [
-            // Add a scene view to the widget tree and set a controller.
-            ArcGISSceneView(
-              controllerProvider: () => _sceneViewController,
-              onSceneViewReady: onSceneViewReady,
-              onTap: onTap,
-            ),
-            // Display a progress indicator and prevent interaction until state is ready.
-            LoadingIndicator(visible: !_ready),
-            // Banner at the top.
-            SafeArea(
-              child: IgnorePointer(
-                child: Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(10),
-                  color: Colors.black.withValues(alpha: 0.5),
-                  child: const Text(
-                    'Tap on the map to move the tank and update the viewshed.',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
+      body: Stack(
+        children: [
+          // Add a scene view to the widget tree and set a controller.
+          ArcGISSceneView(
+            controllerProvider: () => _sceneViewController,
+            onSceneViewReady: onSceneViewReady,
+            onTap: onTap,
+          ),
+          // Display a progress indicator and prevent interaction until state is ready.
+          LoadingIndicator(visible: !_ready),
+          // Banner at the top.
+          const MapBanner(
+            text: 'Tap on the map to move the tank and update the viewshed.',
+          ),
+        ],
       ),
     );
   }

--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
@@ -147,27 +147,10 @@ class _SnapGeometryEditsWithUtilityNetworkRulesState
           // Display a progress indicator and prevent interaction until state is ready.
           LoadingIndicator(visible: !_ready),
           // Display a banner with instructions at the top.
-          SafeArea(
-            left: false,
-            right: false,
-            child: IgnorePointer(
-              child: Container(
-                padding: const EdgeInsets.all(10),
-                color: Colors.white.withValues(alpha: 0.7),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      _selectedElement == null
-                          ? 'Tap a point feature to edit'
-                          : 'Group: ${_selectedElement!.assetGroup.name}, Type: ${_selectedElement!.assetType.name}',
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.labelMedium,
-                    ),
-                  ],
-                ),
-              ),
-            ),
+          MapBanner(
+            text: _selectedElement == null
+                ? 'Tap a point feature to edit'
+                : 'Group: ${_selectedElement!.assetGroup.name}, Type: ${_selectedElement!.assetType.name}',
           ),
         ],
       ),

--- a/lib/samples/trace_utility_network/trace_utility_network.dart
+++ b/lib/samples/trace_utility_network/trace_utility_network.dart
@@ -219,29 +219,7 @@ class _TraceUtilityNetworkState extends State<TraceUtilityNetwork>
             // Loading indicator.
             LoadingIndicator(visible: !_ready),
             // Display a banner with instructions at the top.
-            SafeArea(
-              left: false,
-              right: false,
-              child: IgnorePointer(
-                child: Container(
-                  padding: const EdgeInsets.all(5),
-                  color: Colors.white.withValues(alpha: 0.7),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      FittedBox(
-                        fit: BoxFit.scaleDown,
-                        child: Text(
-                          _message,
-                          textAlign: TextAlign.center,
-                          style: Theme.of(context).textTheme.labelMedium,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+            MapBanner(text: _message),
           ],
         ),
       ),


### PR DESCRIPTION
- Introduces a new widget, `MapBanner`, which displays a string of text on a semi-transparent background that stretches the full width, and is theme-aware. Several samples were doing this, with slight variations, and some with bad interactions with Dark Mode. They have all now been standardized on `MapBanner`.
- Removed some text styles that were no longer in use and had hard-coded white rather than something theme-aware.
- Removed a trailing newline in "Navigate route" sample's banner message, which was adding unnecessary padding on the bottom.
- Removed a couple `SafeArea`s from samples that didn't have any widgets that would make a `SafeArea` necessary.