### PR TITLE
Refactor existing download functionality into a model class

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'dart:convert';
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/api_key_manager.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/theme_data.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/models/offline_data.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/router_config.dart';
 import 'package:flutter/material.dart';
@@ -52,6 +53,7 @@ void main() async {
 
   final prefs = await SharedPreferences.getInstance();
   FavoriteRepository.instance.initialize(prefs);
+  await OfflineDataLocation.instance.initialize();
 
   final jsonString = await rootBundle.loadString(
     'assets/generated_samples_list.json',

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -15,7 +15,10 @@
 //
 
 import 'dart:io';
+import 'package:arcgis_maps/arcgis_maps.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/common/download_util.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
+import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
@@ -52,13 +55,66 @@ class OfflineData {
 
   /// Returns whether all downloadable resources are present in the offline data location.
   bool allResourcesDownloaded() {
+    final basePath = OfflineDataLocation.instance.location.path;
     return downloadableResources.every(
-      (resource) => File(
-        path.join(
-          OfflineDataLocation.instance.location.path,
-          resource.downloadable,
-        ),
-      ).existsSync(),
+      (r) => File(path.join(basePath, r.downloadable)).existsSync(),
     );
+  }
+
+  /// Downloads the resources to the offline data location.
+  ///
+  /// [requestCancelToken] is used to handle cancellation of the download.
+  /// [onProgress] is a callback that provides the download progress as an integer percentage.
+  Future<void> downloadResources({
+    required RequestCancelToken requestCancelToken,
+    void Function(int progress)? onProgress,
+  }) async {
+    final itemIds = downloadableResources.map((r) => r.itemId).toList();
+    final basePath = OfflineDataLocation.instance.location.path;
+    final destinationFiles = downloadableResources
+        .map((r) => File(path.join(basePath, r.downloadable)))
+        .toList();
+
+    await downloadSampleDataWithProgress(
+      itemIds: itemIds,
+      destinationFiles: destinationFiles,
+      requestCancelToken: requestCancelToken,
+      onProgress: onProgress,
+    );
+  }
+
+  /// Cleans up downloaded files and extracted directories for this offline data.
+  ///
+  /// Deletes:
+  /// - The downloaded file (ZIP or non-ZIP)
+  /// - The extracted directory (for ZIP files only)
+  void cleanupFiles() {
+    final basePath = OfflineDataLocation.instance.location.path;
+    try {
+      for (final resource in downloadableResources) {
+        final file = File(path.join(basePath, resource.downloadable));
+        if (file.existsSync()) {
+          file.deleteSync();
+        }
+
+        // For ZIP files, also delete the extracted directory.
+        final isZip = resource.downloadable.toLowerCase().endsWith('.zip');
+        if (isZip) {
+          // Use path.withoutExtension to match the extraction directory naming.
+          final extractionDirName = path.withoutExtension(
+            resource.downloadable,
+          );
+          final extractionDir = Directory(
+            path.join(basePath, extractionDirName),
+          );
+          if (extractionDir.existsSync()) {
+            extractionDir.deleteSync(recursive: true);
+          }
+        }
+      }
+    } on FileSystemException catch (e) {
+      // Ignore errors during cleanup - file may not exist or may be locked.
+      debugPrint('Cleanup warning: ${e.message}');
+    }
   }
 }

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -42,7 +42,7 @@ class OfflineDataLocation {
 class OfflineData {
   /// Creates an [OfflineData] instance from a JSON list of downloadable resources.
   OfflineData.fromJson(List<dynamic> json) {
-    downloadableResources = json
+    _downloadableResources = json
         .map(
           (e) =>
               DownloadableResource.fromJson(e as Map<String, dynamic>? ?? {}),
@@ -51,12 +51,15 @@ class OfflineData {
   }
 
   /// The list of downloadable resources for this offline data.
-  List<DownloadableResource> downloadableResources = [];
+  List<DownloadableResource> _downloadableResources = [];
+
+  /// Whether this offline data has any downloadable resources.
+  bool get hasDownloadableResources => _downloadableResources.isNotEmpty;
 
   /// Returns whether all downloadable resources are present in the offline data location.
   bool allResourcesDownloaded() {
     final basePath = OfflineDataLocation.instance.location.path;
-    return downloadableResources.every(
+    return _downloadableResources.every(
       (r) => File(path.join(basePath, r.downloadable)).existsSync(),
     );
   }
@@ -69,9 +72,9 @@ class OfflineData {
     required RequestCancelToken requestCancelToken,
     void Function(int progress)? onProgress,
   }) async {
-    final itemIds = downloadableResources.map((r) => r.itemId).toList();
+    final itemIds = _downloadableResources.map((r) => r.itemId).toList();
     final basePath = OfflineDataLocation.instance.location.path;
-    final destinationFiles = downloadableResources
+    final destinationFiles = _downloadableResources
         .map((r) => File(path.join(basePath, r.downloadable)))
         .toList();
 
@@ -91,7 +94,7 @@ class OfflineData {
   void cleanupFiles() {
     final basePath = OfflineDataLocation.instance.location.path;
     try {
-      for (final resource in downloadableResources) {
+      for (final resource in _downloadableResources) {
         final file = File(path.join(basePath, resource.downloadable));
         if (file.existsSync()) {
           file.deleteSync();
@@ -116,5 +119,31 @@ class OfflineData {
       // Ignore errors during cleanup - file may not exist or may be locked.
       debugPrint('Cleanup warning: ${e.message}');
     }
+  }
+
+  /// Returns the expected file paths of the downloaded resources after extraction.
+  ///
+  /// For ZIP resources, returns the path to the resource inside the extracted directory.
+  /// For non-ZIP resources, returns the direct file path.
+  List<String> downloadedFilePaths() {
+    final basePath = OfflineDataLocation.instance.location.path;
+    return _downloadableResources.map((r) {
+      // Remove only the trailing extension (e.g., .zip, .vtpk).
+      final downloadableWithoutExt = path.withoutExtension(r.downloadable);
+
+      // Check if this is a ZIP file (using both metadata flag and filename).
+      final isZip = r.downloadable.toLowerCase().endsWith('.zip');
+
+      if (isZip) {
+        // For ZIP files, the structure is:
+        // <appDir>/<downloadableWithoutExt>/<resource>
+        return r.resource != null
+            ? path.join(basePath, downloadableWithoutExt, r.resource)
+            : path.join(basePath, downloadableWithoutExt);
+      } else {
+        // For non-ZIP files, the file is stored directly.
+        return path.join(basePath, r.downloadable);
+      }
+    }).toList();
   }
 }

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -18,7 +18,7 @@ import 'dart:io';
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/download_util.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
@@ -30,23 +30,21 @@ class OfflineDataLocation {
 
   /// Initializes the offline data location by obtaining the application documents directory.
   Future<void> initialize() async {
-    _location = await getApplicationDocumentsDirectory();
+    _location ??= await getApplicationDocumentsDirectory();
   }
 
   /// The directory where offline data is stored.
-  Directory get location => _location;
+  Directory get location => _location!;
 
-  late final Directory _location;
+  Directory? _location;
 }
 
 class OfflineData {
   /// Creates an [OfflineData] instance from a JSON list of downloadable resources.
   OfflineData.fromJson(List<dynamic> json) {
     _downloadableResources = json
-        .map(
-          (e) =>
-              DownloadableResource.fromJson(e as Map<String, dynamic>? ?? {}),
-        )
+        .whereType<Map<String, dynamic>>()
+        .map(DownloadableResource.fromJson)
         .toList(growable: false);
   }
 

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -1,0 +1,64 @@
+//
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import 'dart:io';
+import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+
+class OfflineDataLocation {
+  // Private constructor to enforce singleton pattern.
+  OfflineDataLocation._();
+
+  static final instance = OfflineDataLocation._();
+
+  /// Initializes the offline data location by obtaining the application documents directory.
+  Future<void> initialize() async {
+    _location = await getApplicationDocumentsDirectory();
+  }
+
+  /// The directory where offline data is stored.
+  Directory get location => _location;
+
+  late final Directory _location;
+}
+
+class OfflineData {
+  /// Creates an [OfflineData] instance from a JSON list of downloadable resources.
+  OfflineData.fromJson(List<dynamic> json) {
+    downloadableResources = json
+        .map(
+          (e) =>
+              DownloadableResource.fromJson(e as Map<String, dynamic>? ?? {}),
+        )
+        .toList(growable: false);
+  }
+
+  /// The list of downloadable resources for this offline data.
+  List<DownloadableResource> downloadableResources = [];
+
+  /// Returns whether all downloadable resources are present in the offline data location.
+  bool allResourcesDownloaded() {
+    return downloadableResources.every(
+      (resource) => File(
+        path.join(
+          OfflineDataLocation.instance.location.path,
+          resource.downloadable,
+        ),
+      ).existsSync(),
+    );
+  }
+}

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -63,10 +63,6 @@ class Sample {
 
   OfflineData get offlineData => _offlineData;
 
-  /// Returns true if this sample requires downloadable resources.
-  bool get hasDownloadableResources =>
-      _offlineData.downloadableResources.isNotEmpty;
-
   Widget getSampleWidget() => _sampleWidget;
 }
 

--- a/lib/models/sample.dart
+++ b/lib/models/sample.dart
@@ -17,7 +17,7 @@
 import 'dart:async';
 
 // run `dart run build_runner build` to generate samples_widget_list.dart
-import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/models/offline_data.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/samples_widget_list.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -33,9 +33,7 @@ class Sample {
       _title = json['title'] as String? ?? '',
       _keywords = List<String>.from(json['keywords'] as List? ?? []),
       _key = json['key'] as String? ?? '',
-      _downloadableResources = _parseDownloadableResources(
-        json['offline_data'] as List? ?? [],
-      ),
+      _offlineData = OfflineData.fromJson(json['offline_data'] as List? ?? []),
       _sampleWidget = sampleWidgets[json['key']]!();
   final String _category;
   final String _description;
@@ -44,16 +42,7 @@ class Sample {
   final List<String> _keywords;
   final Widget _sampleWidget;
   final String _key;
-  final List<DownloadableResource> _downloadableResources;
-
-  static List<DownloadableResource> _parseDownloadableResources(
-    List<dynamic> resources,
-  ) {
-    return resources
-        .whereType<Map<String, dynamic>>()
-        .map(DownloadableResource.fromJson)
-        .toList();
-  }
+  final OfflineData _offlineData;
 
   String get title => _title;
 
@@ -72,11 +61,11 @@ class Sample {
   set isFavorite(bool value) =>
       FavoriteRepository.instance.setFavorite(_key, value);
 
-  List<DownloadableResource> get downloadableResources =>
-      _downloadableResources;
+  OfflineData get offlineData => _offlineData;
 
   /// Returns true if this sample requires downloadable resources.
-  bool get hasDownloadableResources => _downloadableResources.isNotEmpty;
+  bool get hasDownloadableResources =>
+      _offlineData.downloadableResources.isNotEmpty;
 
   Widget getSampleWidget() => _sampleWidget;
 }

--- a/lib/router_config.dart
+++ b/lib/router_config.dart
@@ -89,7 +89,7 @@ GoRouter routerConfig(List<Sample> allSamples) {
 
               return DownloadableResourcesPage(
                 sampleTitle: sample.title,
-                resources: sample.downloadableResources,
+                offlineData: sample.offlineData,
                 onComplete: (downloadPaths) {
                   context.pushReplacement(
                     '/sample/${sample.key}/live',
@@ -138,7 +138,7 @@ GoRouter routerConfigWithSample(Sample sample, String initialLocation) {
         builder: (context, state) {
           return DownloadableResourcesPage(
             sampleTitle: sample.title,
-            resources: sample.downloadableResources,
+            offlineData: sample.offlineData,
             onComplete: (downloadPaths) {
               context.go('/${sample.key}/live', extra: downloadPaths);
             },

--- a/lib/samples/find_route_in_mobile_map_package/README.metadata.json
+++ b/lib/samples/find_route_in_mobile_map_package/README.metadata.json
@@ -28,11 +28,11 @@
     "offline_data": [
       {
         "itemId": "e1f3a7254cb845b09450f54937c16061",
-        "downloadable": "SanFrancisco.mmpk"
+        "downloadable": "Yellowstone.mmpk"
       },
       {
         "itemId": "260eb6535c824209964cf281766ebe43",
-        "downloadable": "Yellowstone.mmpk"
+        "downloadable": "SanFrancisco.mmpk"
       }
     ],
     "redirect_from": [],

--- a/lib/samples/navigate_route_with_rerouting/README.metadata.json
+++ b/lib/samples/navigate_route_with_rerouting/README.metadata.json
@@ -32,7 +32,7 @@
       },
       {
         "itemId": "4caec8c55ea2463982f1af7d9611b8d5",
-        "downloadable": "SanDiegoTourPath.zip",
+        "downloadable": "SanDiegoTourPath.json.zip",
         "resource": "SanDiegoTourPath.json"
       }
     ],

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -18,6 +18,7 @@ import 'dart:convert';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/models/offline_data.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/sample.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/router_config.dart';
 import 'package:flutter/material.dart';
@@ -42,6 +43,7 @@ void main() async {
 
   final prefs = await SharedPreferences.getInstance();
   FavoriteRepository.instance.initialize(prefs);
+  await OfflineDataLocation.instance.initialize();
 
   final jsonString = await rootBundle.loadString(
     'assets/generated_samples_list.json',

--- a/lib/utils/sample_runner.dart
+++ b/lib/utils/sample_runner.dart
@@ -58,7 +58,7 @@ void main() async {
     return s.key == sampleFolderName;
   });
 
-  final initialRoute = sample.hasDownloadableResources
+  final initialRoute = sample.offlineData.hasDownloadableResources
       ? '/${sample.key}/resources'
       : '/${sample.key}/live';
 

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -194,7 +194,9 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       await widget.offlineData.downloadResources(
         requestCancelToken: _requestCancelToken,
         onProgress: (progress) {
-          setState(() => _progress = progress);
+          if (mounted) {
+            setState(() => _progress = progress);
+          }
         },
       );
 
@@ -226,11 +228,13 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
 
       widget.offlineData.cleanupFiles();
 
-      setState(() {
-        _isDownloading = false;
-        _isComplete = false;
-        _progress = 0;
-      });
+      if (mounted) {
+        setState(() {
+          _isDownloading = false;
+          _isComplete = false;
+          _progress = 0;
+        });
+      }
     }
   }
 

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -199,19 +199,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
     });
 
     try {
-      final appDir = await getApplicationDocumentsDirectory();
-      final itemIds = widget.offlineData.downloadableResources
-          .map((r) => r.itemId)
-          .toList();
-      final destinationFiles = widget.offlineData.downloadableResources.map((
-        r,
-      ) {
-        return File(path.join(appDir.absolute.path, r.downloadable));
-      }).toList();
-
-      await downloadSampleDataWithProgress(
-        itemIds: itemIds,
-        destinationFiles: destinationFiles,
+      await widget.offlineData.downloadResources(
         requestCancelToken: _requestCancelToken,
         onProgress: (progress) {
           setState(() => _progress = progress);
@@ -224,7 +212,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       });
 
       // directly open the sample after downloading
-      unawaited(_openSample());
+      _openSample().ignore();
     } on Exception catch (e) {
       // show a snackbar with error message
       if (mounted) {
@@ -242,7 +230,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
         ).showSnackBar(SnackBar(content: Text(message)));
       }
 
-      await _cleanupFiles();
+      widget.offlineData.cleanupFiles();
 
       setState(() {
         _isDownloading = false;
@@ -257,6 +245,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   /// For ZIP resources, returns the path to the resource inside the extracted directory.
   /// For non-ZIP resources, returns the direct file path.
   Future<List<String>> _getDownloadFilePaths() async {
+    //fixme
     final appDir = await getApplicationDocumentsDirectory();
     return widget.offlineData.downloadableResources.map((res) {
       // Remove only the trailing extension (e.g., .zip, .vtpk).
@@ -280,44 +269,6 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
         return path.join(appDir.absolute.path, res.downloadable);
       }
     }).toList();
-  }
-
-  /// Cleans up partially downloaded files and extracted directories.
-  ///
-  /// Deletes:
-  /// - The downloaded file (ZIP or non-ZIP)
-  /// - The extracted directory (for ZIP files only)
-  Future<void> _cleanupFiles() async {
-    final appDir = await getApplicationDocumentsDirectory();
-    for (final resource in widget.offlineData.downloadableResources) {
-      try {
-        // Delete the downloaded file.
-        final downloadedFile = File(
-          path.join(appDir.absolute.path, resource.downloadable),
-        );
-        if (downloadedFile.existsSync()) {
-          downloadedFile.deleteSync();
-        }
-
-        // For ZIP files, also delete the extracted directory.
-        final isZip = resource.downloadable.toLowerCase().endsWith('.zip');
-        if (isZip) {
-          // Use path.withoutExtension to match the extraction directory naming.
-          final extractionDirName = path.withoutExtension(
-            resource.downloadable,
-          );
-          final extractionDir = Directory(
-            path.join(appDir.absolute.path, extractionDirName),
-          );
-          if (extractionDir.existsSync()) {
-            extractionDir.deleteSync(recursive: true);
-          }
-        }
-      } on FileSystemException catch (e) {
-        // Ignore errors during cleanup - file may not exist or may be locked.
-        debugPrint('Cleanup warning: ${e.message}');
-      }
-    }
   }
 
   // Cancel the ongoing download.

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/download_util.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/models/downloadable_resource.dart';
+import 'package:arcgis_maps_sdk_flutter_samples/models/offline_data.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path/path.dart' as path;
@@ -36,13 +36,13 @@ typedef OnComplete = void Function(List<String>);
 class DownloadableResourcesPage extends StatefulWidget {
   const DownloadableResourcesPage({
     required this.sampleTitle,
-    required this.resources,
+    required this.offlineData,
     required this.onComplete,
     super.key,
   });
 
   final String sampleTitle;
-  final List<DownloadableResource> resources;
+  final OfflineData offlineData;
   final OnComplete onComplete;
 
   @override
@@ -62,7 +62,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   @override
   void initState() {
     super.initState();
-    _checkIfResourcesExist().ignore();
+    _checkIfResourcesExist();
   }
 
   @override
@@ -178,19 +178,8 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   }
 
   // Check if all resources already exist.
-  Future<void> _checkIfResourcesExist() async {
-    final appDir = await getApplicationDocumentsDirectory();
-    var allResourcesExist = true;
-
-    for (final resource in widget.resources) {
-      final file = File(path.join(appDir.absolute.path, resource.downloadable));
-      if (!file.existsSync()) {
-        allResourcesExist = false;
-        break;
-      }
-    }
-
-    if (allResourcesExist) {
+  void _checkIfResourcesExist() {
+    if (widget.offlineData.allResourcesDownloaded()) {
       setState(() {
         _isComplete = true;
         _progress = 100;
@@ -198,9 +187,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       });
 
       // if the data has been downloaded, directly open the sample.
-      if (mounted) {
-        unawaited(_openSample());
-      }
+      _openSample().ignore();
     }
   }
 
@@ -213,8 +200,12 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
 
     try {
       final appDir = await getApplicationDocumentsDirectory();
-      final itemIds = widget.resources.map((r) => r.itemId).toList();
-      final destinationFiles = widget.resources.map((r) {
+      final itemIds = widget.offlineData.downloadableResources
+          .map((r) => r.itemId)
+          .toList();
+      final destinationFiles = widget.offlineData.downloadableResources.map((
+        r,
+      ) {
         return File(path.join(appDir.absolute.path, r.downloadable));
       }).toList();
 
@@ -267,7 +258,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   /// For non-ZIP resources, returns the direct file path.
   Future<List<String>> _getDownloadFilePaths() async {
     final appDir = await getApplicationDocumentsDirectory();
-    return widget.resources.map((res) {
+    return widget.offlineData.downloadableResources.map((res) {
       // Remove only the trailing extension (e.g., .zip, .vtpk).
       final downloadableWithoutExt = path.withoutExtension(res.downloadable);
 
@@ -298,7 +289,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   /// - The extracted directory (for ZIP files only)
   Future<void> _cleanupFiles() async {
     final appDir = await getApplicationDocumentsDirectory();
-    for (final resource in widget.resources) {
+    for (final resource in widget.offlineData.downloadableResources) {
       try {
         // Delete the downloaded file.
         final downloadedFile = File(

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -15,14 +15,10 @@
 //
 
 import 'dart:async';
-import 'dart:io';
 import 'package:arcgis_maps/arcgis_maps.dart';
-import 'package:arcgis_maps_sdk_flutter_samples/common/download_util.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/models/offline_data.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:path/path.dart' as path;
-import 'package:path_provider/path_provider.dart';
 
 typedef OnComplete = void Function(List<String>);
 
@@ -62,7 +58,15 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
   @override
   void initState() {
     super.initState();
-    _checkIfResourcesExist();
+
+    if (widget.offlineData.allResourcesDownloaded()) {
+      _isComplete = true;
+      _progress = 100;
+      _shouldShowUI = false;
+
+      // if the data has already been downloaded, immediately open the sample.
+      WidgetsBinding.instance.addPostFrameCallback((_) => _openSample());
+    }
   }
 
   @override
@@ -177,20 +181,6 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
     }
   }
 
-  // Check if all resources already exist.
-  void _checkIfResourcesExist() {
-    if (widget.offlineData.allResourcesDownloaded()) {
-      setState(() {
-        _isComplete = true;
-        _progress = 100;
-        _shouldShowUI = false;
-      });
-
-      // if the data has been downloaded, directly open the sample.
-      _openSample().ignore();
-    }
-  }
-
   // Start the download of resources.
   Future<void> _startDownload() async {
     setState(() {
@@ -212,7 +202,7 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       });
 
       // directly open the sample after downloading
-      _openSample().ignore();
+      _openSample();
     } on Exception catch (e) {
       // show a snackbar with error message
       if (mounted) {
@@ -240,45 +230,14 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
     }
   }
 
-  /// Returns the expected file paths of the downloaded resources after extraction.
-  ///
-  /// For ZIP resources, returns the path to the resource inside the extracted directory.
-  /// For non-ZIP resources, returns the direct file path.
-  Future<List<String>> _getDownloadFilePaths() async {
-    //fixme
-    final appDir = await getApplicationDocumentsDirectory();
-    return widget.offlineData.downloadableResources.map((res) {
-      // Remove only the trailing extension (e.g., .zip, .vtpk).
-      final downloadableWithoutExt = path.withoutExtension(res.downloadable);
-
-      // Check if this is a ZIP file (using both metadata flag and filename).
-      final isZip = res.downloadable.toLowerCase().endsWith('.zip');
-
-      if (isZip) {
-        // For ZIP files, the structure is:
-        // <appDir>/<downloadableWithoutExt>/<resource>
-        return res.resource != null
-            ? path.join(
-                appDir.absolute.path,
-                downloadableWithoutExt,
-                res.resource,
-              )
-            : path.join(appDir.absolute.path, downloadableWithoutExt);
-      } else {
-        // For non-ZIP files, the file is stored directly.
-        return path.join(appDir.absolute.path, res.downloadable);
-      }
-    }).toList();
-  }
-
   // Cancel the ongoing download.
   void _cancelDownload() {
     _requestCancelToken.cancel();
   }
 
   // Call back to onComplete.
-  Future<void> _openSample() async {
-    final downloadPaths = await _getDownloadFilePaths();
+  void _openSample() {
+    final downloadPaths = widget.offlineData.downloadedFilePaths();
     widget.onComplete(downloadPaths);
   }
 }

--- a/lib/widgets/downloadable_resources_page.dart
+++ b/lib/widgets/downloadable_resources_page.dart
@@ -65,7 +65,9 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
       _shouldShowUI = false;
 
       // if the data has already been downloaded, immediately open the sample.
-      WidgetsBinding.instance.addPostFrameCallback((_) => _openSample());
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _openSample();
+      });
     }
   }
 
@@ -195,6 +197,8 @@ class _DownloadableResourcesPageState extends State<DownloadableResourcesPage> {
           setState(() => _progress = progress);
         },
       );
+
+      if (!mounted) return;
 
       setState(() {
         _isComplete = true;

--- a/lib/widgets/sample_list_view.dart
+++ b/lib/widgets/sample_list_view.dart
@@ -47,7 +47,7 @@ class SampleListView extends StatelessWidget {
               subtitle: Text(sample.description),
               onTap: () async {
                 if (context.mounted) {
-                  if (sample.hasDownloadableResources) {
+                  if (sample.offlineData.hasDownloadableResources) {
                     unawaited(context.push('/sample/${sample.key}/resources'));
                   } else {
                     unawaited(context.push('/sample/${sample.key}/live'));


### PR DESCRIPTION
Refactors the existing download logic into a separate `OfflineData` class. The functionality remains the same, with only one real difference -- `getApplicationDocumentsDirectory()` is only called once at startup, rather than with every method call. (This allows more of the methods to be not-async.)

This is part of a longer goal of changing some of the functionality so that we only have to specify `itemId` in the `offline_data` JSON. (The `downloadable` and `resource` values can be determined by loading the `PortalItem`.) That will be done in a later PR.

While I was working with the `offline_data` in the JSON, I found two samples where the `downloadable` value doesn't match the `PortalItem.name`. In one, SanFrancisco and Yellowstone were accidentally swapped, and in the other, it was missing a `.json` from the filename. This doesn't affect the functionality of those two samples.