### PR TITLE
restore this bit of README as designed

### DIFF
--- a/lib/samples/add_vector_tiled_layer_from_custom_style/README.md
+++ b/lib/samples/add_vector_tiled_layer_from_custom_style/README.md
@@ -33,7 +33,7 @@ Pan and zoom to explore the vector tile basemap. Select a theme to see it applie
 
 ## Offline data
 
-[Dodge City OSM vector tile package](https://www.arcgis.com/home/item.html?id=f4b742a57af344988b02227e2824ca5f)
+This sample uses the [Dodge City OSM](https://www.arcgis.com/home/item.html?id=f4b742a57af344988b02227e2824ca5f) vector tile package. It is downloaded from ArcGIS Online automatically.
 
 ## Tags
 


### PR DESCRIPTION
The AI changed the "Offline data" section unnecessarily and I didn't catch it. There's no reason to diverge from the design here, so I'll put it back to match the design.