### PR TITLE
simplify exception handling

### DIFF
--- a/lib/common/sample_state_support.dart
+++ b/lib/common/sample_state_support.dart
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 
@@ -34,5 +35,19 @@ mixin SampleStateSupport<T extends StatefulWidget> on State<T> {
     if (mounted) {
       showAlertDialog(context, message, title: title, showOK: showOK).ignore();
     }
+  }
+
+  void showExceptionDialog(
+    String message,
+    Exception e, {
+    String title = 'Error',
+    bool showOK = false,
+  }) {
+    final exceptionMessage = e is ArcGISException ? e.message : e.toString();
+    showMessageDialog(
+      '$message: $exceptionMessage',
+      title: title,
+      showOK: showOK,
+    );
   }
 }

--- a/lib/samples/add_vector_tiled_layer_from_custom_style/add_vector_tiled_layer_from_custom_style.dart
+++ b/lib/samples/add_vector_tiled_layer_from_custom_style/add_vector_tiled_layer_from_custom_style.dart
@@ -180,12 +180,8 @@ class _AddVectorTiledLayerFromCustomStyleState
           ),
         );
       }
-    } on ArcGISException catch (e) {
-      // Show ArcGIS runtime failures.
-      showMessageDialog(e.message, title: 'ArcGIS Error');
     } on Exception catch (e) {
-      // Show non-ArcGIS failures.
-      showMessageDialog(e.toString(), title: 'Error');
+      showExceptionDialog('Failed to apply style selection', e);
     } finally {
       // Re-enable interactions after style work completes.
       setState(() => _ready = true);

--- a/lib/samples/analyze_hotspots/analyze_hotspots.dart
+++ b/lib/samples/analyze_hotspots/analyze_hotspots.dart
@@ -153,7 +153,7 @@ class _AnalyzeHotspotsState extends State<AnalyzeHotspots>
       // Mark the task load as failed so the loading indicator can be hidden.
       setState(() => _taskLoadFailed = true);
       // Show the task loading error to the user.
-      showMessageDialog('Failed to load geoprocessing task:\n$e');
+      showExceptionDialog('Failed to load geoprocessing task', e);
     }
   }
 

--- a/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area.dart
+++ b/lib/samples/apply_scheduled_updates_to_preplanned_map_area/apply_scheduled_updates_to_preplanned_map_area.dart
@@ -131,10 +131,7 @@ class _ApplyScheduledUpdatesToPreplannedMapAreaState
         await _loadMapPackageMap();
       }
     } on ArcGISException catch (e) {
-      showMessageDialog(
-        'The offline map sync failed with error: {$e}.',
-        title: 'Error',
-      );
+      showExceptionDialog('The offline map sync failed with error', e);
     } finally {
       // Refresh the update status.
       await _checkForUpdates();
@@ -164,10 +161,7 @@ class _ApplyScheduledUpdatesToPreplannedMapAreaState
     try {
       await _mobileMapPackage!.load();
     } on ArcGISException catch (e) {
-      showMessageDialog(
-        'Mobile Map Package failed to load with error: {$e}',
-        title: 'Error',
-      );
+      showExceptionDialog('Mobile Map Package failed to load with error', e);
       return false;
     }
 

--- a/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
+++ b/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
@@ -138,16 +138,8 @@ class _ConfigureElectronicNavigationalChartsState
         }),
       );
       map.operationalLayers.addAll(_encLayers);
-    } on ArcGISException catch (e) {
-      showMessageDialog(
-        'Failed to load electronic navigational charts: ${e.message}',
-        title: 'Error',
-      );
     } on Exception catch (e) {
-      showMessageDialog(
-        'Failed to configure electronic navigational charts: $e',
-        title: 'Error',
-      );
+      showExceptionDialog('Failed to load electronic navigational charts', e);
     } finally {
       // Set the ready state variable to true to hide the loading indicator.
       setState(() => _ready = true);

--- a/lib/samples/control_annotation_sublayer_visibility/control_annotation_sublayer_visibility.dart
+++ b/lib/samples/control_annotation_sublayer_visibility/control_annotation_sublayer_visibility.dart
@@ -180,12 +180,8 @@ class _ControlAnnotationSublayerVisibilityState
 
       // Set the ready state variable to true to enable the sample UI.
       setState(() => _ready = true);
-    } on ArcGISException catch (e) {
-      showMessageDialog('${e.message}.');
-    } on Exception {
-      showMessageDialog(
-        'There was an error loading the data required for the sample.',
-      );
+    } on Exception catch (e) {
+      showExceptionDialog('Failed to load annotation sublayers', e);
     }
   }
 }

--- a/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
+++ b/lib/samples/create_mobile_geodatabase/create_mobile_geodatabase.dart
@@ -145,7 +145,7 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
       _geodatabase = await Geodatabase.create(fileUri: geodatabaseFile.uri);
       await _createGeodatabaseFeatureTable();
     } on Exception catch (e) {
-      showMessageDialog(e.toString(), title: 'Error');
+      showExceptionDialog('Failed to create mobile geodatabase', e);
     }
     return Future.value();
   }
@@ -172,7 +172,7 @@ class _CreateMobileGeodatabaseState extends State<CreateMobileGeodatabase>
       _map.operationalLayers.add(FeatureLayer.withFeatureTable(_featureTable!));
       setState(() => _featureCount = _featureTable!.numberOfFeatures);
     } on ArcGISException catch (e) {
-      showMessageDialog(e.toString(), title: 'Error');
+      showExceptionDialog('Failed to create feature table', e);
     }
     return Future.value();
   }

--- a/lib/samples/create_symbol_styles_from_web_styles/create_symbol_styles_from_web_styles.dart
+++ b/lib/samples/create_symbol_styles_from_web_styles/create_symbol_styles_from_web_styles.dart
@@ -209,7 +209,7 @@ class _CreateSymbolStylesFromWebStylesState
       legendItems.sort((a, b) => a.name.compareTo(b.name));
       _legendItems.addAll(legendItems);
     } on Exception catch (e) {
-      showMessageDialog('Error updating symbols: $e');
+      showExceptionDialog('Error updating symbols', e);
     }
   }
 }

--- a/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
+++ b/lib/samples/download_vector_tiles_to_local_cache/download_vector_tiles_to_local_cache.dart
@@ -229,7 +229,7 @@ class _DownloadVectorTilesToLocalCacheState
       // If the job succeeded, load the downloaded caches into the map view.
       _loadExportedVectorTiles(result);
     } on ArcGISException catch (e) {
-      showMessageDialog('Failed to download vector tiles: ${e.message}');
+      showExceptionDialog('Failed to load vector tiles', e);
     } finally {
       _exportVectorTilesJob = null;
     }

--- a/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
+++ b/lib/samples/edit_feature_attachments/edit_feature_attachments.dart
@@ -111,7 +111,7 @@ class _EditFeatureAttachmentsState extends State<EditFeatureAttachments>
       // Apply the edits to the service.
       await serviceFeatureTable.applyEdits();
     } on ArcGISException catch (e) {
-      showMessageDialog(e.toString(), title: 'Error', showOK: true);
+      showExceptionDialog('Failed to apply edits', e, showOK: true);
     }
     return Future.value();
   }
@@ -312,7 +312,7 @@ class _AttachmentsOptionsState extends State<AttachmentsOptions>
         _isLoading = false;
       });
     } on ArcGISException catch (e) {
-      showMessageDialog(e.toString(), title: 'Error', showOK: true);
+      showExceptionDialog('Failed to load attachments', e, showOK: true);
       setState(() => _isLoading = false);
     }
   }

--- a/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
+++ b/lib/samples/find_route_in_mobile_map_package/find_route_in_mobile_map_package.dart
@@ -351,7 +351,7 @@ class _FindRouteInMapState extends State<FindRouteInMap>
       // If an error occurs, clear the route overlay and display the error.
       _routeOverlay!.graphics.clear();
 
-      showMessageDialog(e.message, title: 'Error');
+      showExceptionDialog('Failed to solve route', e);
     }
   }
 

--- a/lib/samples/generate_geodatabase_replica_from_feature_service/generate_geodatabase_replica_from_feature_service.dart
+++ b/lib/samples/generate_geodatabase_replica_from_feature_service/generate_geodatabase_replica_from_feature_service.dart
@@ -209,15 +209,8 @@ class _GenerateGeodatabaseReplicaFromFeatureServiceState
         _ready = true;
         _statusMessage = 'Tap the generate button to take the area offline.';
       });
-    } on ArcGISException catch (e) {
-      // Show ArcGIS errors raised while loading the task or map.
-      showMessageDialog(e.message, title: 'Error');
-    } on FileSystemException catch (e) {
-      // Show local file errors raised while finding the downloaded basemap.
-      showMessageDialog(e.message, title: 'Error');
     } on Exception catch (e) {
-      // Show any local file or routing errors raised during setup.
-      showMessageDialog(e.toString(), title: 'Error');
+      showExceptionDialog('Failed to load sample data', e);
     }
   }
 
@@ -339,7 +332,11 @@ class _GenerateGeodatabaseReplicaFromFeatureServiceState
         try {
           await _geodatabaseSyncTask.unregisterGeodatabase(geodatabase);
         } on ArcGISException catch (e) {
-          showMessageDialog(e.message, title: 'Warning');
+          showExceptionDialog(
+            'Failed to unregister geodatabase',
+            e,
+            title: 'Warning',
+          );
         }
       } catch (_) {
         // Ensure local resources are released if loading/display fails.
@@ -361,7 +358,7 @@ class _GenerateGeodatabaseReplicaFromFeatureServiceState
 
       // Report failures unless the user canceled the job.
       if (e.errorType != ArcGISExceptionType.commonUserCanceled) {
-        showMessageDialog(e.message, title: 'Error');
+        showExceptionDialog('Failed to generate geodatabase', e);
       }
     } on Exception catch (e) {
       // Reset generation state for unexpected errors (for example, local file I/O).
@@ -369,7 +366,7 @@ class _GenerateGeodatabaseReplicaFromFeatureServiceState
         _progress = null;
         _statusMessage = 'Tap the generate button to take the area offline.';
       });
-      showMessageDialog(e.toString(), title: 'Error');
+      showExceptionDialog('Failed to generate geodatabase', e);
     } finally {
       // Clear job state and progress listeners after completion.
       _generateGeodatabaseJob = null;

--- a/lib/samples/manage_features/manage_features.dart
+++ b/lib/samples/manage_features/manage_features.dart
@@ -172,12 +172,8 @@ class _ManageFeaturesState extends State<ManageFeatures>
       );
       // Set the ready state variable to true to enable the sample UI.
       setState(() => _ready = true);
-    } on ArcGISException catch (e) {
-      showMessageDialog('${e.message}.');
-    } on Exception {
-      showMessageDialog(
-        'There was an error loading the data required for the sample.',
-      );
+    } on Exception catch (e) {
+      showExceptionDialog('Failed to load sample data', e);
     }
   }
 

--- a/lib/samples/show_device_location/show_device_location.dart
+++ b/lib/samples/show_device_location/show_device_location.dart
@@ -210,7 +210,7 @@ class _ShowDeviceLocationState extends State<ShowDeviceLocation>
     try {
       await _locationDataSource.start();
     } on ArcGISException catch (e) {
-      showMessageDialog(e.message);
+      showExceptionDialog('Failed to start location data source', e);
     }
 
     // Set the ready state variable to true to enable the UI.

--- a/lib/samples/show_device_location_history/show_device_location_history.dart
+++ b/lib/samples/show_device_location_history/show_device_location_history.dart
@@ -162,7 +162,7 @@ class _ShowDeviceLocationHistoryState extends State<ShowDeviceLocationHistory>
     try {
       await _locationDataSource.start();
     } on ArcGISException catch (e) {
-      showMessageDialog(e.message);
+      showExceptionDialog('Failed to start location data source', e);
     }
 
     // Listen for location changes.

--- a/lib/samples/show_service_area/show_service_area.dart
+++ b/lib/samples/show_service_area/show_service_area.dart
@@ -180,7 +180,7 @@ class _ShowServiceAreaState extends State<ShowServiceArea>
       _serviceAreaParameters.defaultImpedanceCutoffs.clear();
       _serviceAreaParameters.defaultImpedanceCutoffs.addAll([3, 8, 12]);
     } on Exception catch (e) {
-      showMessageDialog('Error creating service area parameters:\n $e');
+      showExceptionDialog('Failed to create service area parameters', e);
     }
 
     // Toggle the _ready flag to enable the UI.

--- a/lib/samples/update_basemap_for_contrast_accessibility/update_basemap_for_contrast_accessibility.dart
+++ b/lib/samples/update_basemap_for_contrast_accessibility/update_basemap_for_contrast_accessibility.dart
@@ -281,10 +281,10 @@ class _UpdateBasemapForContrastAccessibilityState
         _contrastAppearance = appearance;
         _ready = true;
       });
-    } on ArcGISException catch (error) {
+    } on ArcGISException catch (e) {
       // Show ArcGIS load failures in the shared sample dialog.
       if (!mounted) return;
-      showMessageDialog(error.message, title: 'Error', showOK: true);
+      showExceptionDialog('Failed to load basemap for contrast appearance', e);
       setState(() => _ready = true);
     }
   }

--- a/lib/samples/validate_utility_network_topology/validate_utility_network_topology.dart
+++ b/lib/samples/validate_utility_network_topology/validate_utility_network_topology.dart
@@ -526,7 +526,7 @@ class _ValidateUtilityNetworkTopologyState
       });
     } on ArcGISException catch (e) {
       // If the trace fails update the status.
-      showMessageDialog(e.additionalMessage, title: e.message, showOK: true);
+      showExceptionDialog('Trace failed', e);
       setState(() {
         _statusTitle = 'Trace failed:';
         _statusDetail = "Tap 'Get State' to check the updated network state.";


### PR DESCRIPTION
We have many exception "catch" blocks that display the exception in an AlertDialog. Here we make all the exception messages simplified and uniform. The intent is to reduce the amount of bulk that distracts from reading the code as a tutorial.