### PR TITLE
replace flutter_tts with stts

### DIFF
--- a/lib/samples/navigate_route/navigate_route.dart
+++ b/lib/samples/navigate_route/navigate_route.dart
@@ -14,13 +14,11 @@
 //
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_tts/flutter_tts.dart';
+import 'package:stts/stts.dart';
 
 class NavigateRoute extends StatefulWidget {
   const NavigateRoute({super.key});
@@ -45,7 +43,7 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
   final _directionsList = <DirectionManeuver>[];
 
   // Third-party plugin for text-to-speech.
-  final _flutterTts = FlutterTts();
+  final _tts = Tts();
 
   // Create a simulated location data source from the route geometry.
   final _simulatedLocationDataSource = SimulatedLocationDataSource();
@@ -124,7 +122,8 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
     _simulatedLocationDataSource.stop().ignore();
     _startedSubscription?.cancel().ignore();
     _autoPanModeSubscription?.cancel().ignore();
-    _flutterTts.stop().ignore();
+    _tts.stop().ignore();
+    _tts.dispose().ignore();
     super.dispose();
   }
 
@@ -198,8 +197,8 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
     // Solve the route.
     await solveRoute();
 
-    // Initialize Flutter TTS.
-    await initFlutterTts();
+    // Initialize TTS.
+    await initTts();
 
     // Set the initial viewpoint to encompass the route geometry.
     setInitialViewpoint();
@@ -208,30 +207,15 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
     setState(() => _ready = true);
   }
 
-  Future<void> initFlutterTts() async {
+  Future<void> initTts() async {
     // Detect the user's locale.
     final locale = Localizations.localeOf(context).toLanguageTag();
 
     // Set the language based on the user's locale.
-    await _flutterTts.setLanguage(locale);
-    await _flutterTts.setSpeechRate(0.5);
-    await _flutterTts.setVolume(1);
-    await _flutterTts.setPitch(1.3);
-
-    // Check if platform is iOS.
-    final isIOS = !kIsWeb && Platform.isIOS;
-
-    if (isIOS) {
-      await _flutterTts.setIosAudioCategory(
-        IosTextToSpeechAudioCategory.playback,
-        [
-          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
-          IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP,
-          IosTextToSpeechAudioCategoryOptions.mixWithOthers,
-        ],
-        IosTextToSpeechAudioMode.voicePrompt,
-      );
-    }
+    await _tts.setLanguage(locale);
+    await _tts.setRate(0.5);
+    await _tts.setVolume(1);
+    await _tts.setPitch(1.3);
   }
 
   void setInitialViewpoint() {
@@ -357,7 +341,7 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
     // Listen for voice guidance updates.
     _routeTracker.onNewVoiceGuidance.listen((voiceGuidance) async {
       _speechEngineReady = false;
-      await _flutterTts.speak(voiceGuidance.text);
+      await _tts.start(voiceGuidance.text);
       _speechEngineReady = true;
     });
   }
@@ -439,7 +423,7 @@ Next direction: ${_directionsList[status.currentManeuverIndex + 1].directionText
     _routeGraphicsOverlay.graphics.add(_routeTraveledGraphic);
 
     // Stop any ongoing speech.
-    await _flutterTts.stop();
+    await _tts.stop();
 
     // Reset the status text.
     _statusTextNotifier.value = 'Directions are shown here.';

--- a/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
+++ b/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
@@ -18,10 +18,9 @@ import 'dart:io';
 
 import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_tts/flutter_tts.dart';
 import 'package:go_router/go_router.dart';
+import 'package:stts/stts.dart';
 
 class NavigateRouteWithRerouting extends StatefulWidget {
   const NavigateRouteWithRerouting({super.key});
@@ -40,7 +39,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
   var _ready = false;
 
   // A text-to-speech plugin to provide voice guidance.
-  late FlutterTts _flutterTts;
+  final _tts = Tts();
 
   // A RouteTask to solve the route.
   late RouteTask _routeTask;
@@ -263,7 +262,8 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
 
   @override
   void dispose() {
-    _flutterTts.stop().ignore();
+    _tts.stop().ignore();
+    _tts.dispose().ignore();
     _simulatedLocationDataSource?.stop().ignore();
     _voiceGuidanceSubscription?.cancel().ignore();
     _trackingStatusSubscription?.cancel().ignore();
@@ -292,38 +292,22 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
       }
     });
 
-    // Initialize FlutterTts.
-    await initFlutterTts();
+    // Initialize TTS.
+    await initTts();
 
     setState(() => _ready = true);
   }
 
-  // Initialize the FlutterTts plugin.
-  Future<void> initFlutterTts() async {
+  // Initialize the TTS plugin.
+  Future<void> initTts() async {
     // Detect the user's locale.
     final locale = Localizations.localeOf(context).toLanguageTag();
 
-    _flutterTts = FlutterTts();
-
     // Set the language based on the user's locale.
-    await _flutterTts.setLanguage(locale);
-    await _flutterTts.setSpeechRate(0.5);
-    await _flutterTts.setVolume(1);
-    await _flutterTts.setPitch(1.3);
-
-    // Perform iOS-specific initialization.
-    final isIOS = !kIsWeb && Platform.isIOS;
-    if (isIOS) {
-      await _flutterTts.setIosAudioCategory(
-        IosTextToSpeechAudioCategory.playback,
-        [
-          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
-          IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP,
-          IosTextToSpeechAudioCategoryOptions.mixWithOthers,
-        ],
-        IosTextToSpeechAudioMode.voicePrompt,
-      );
-    }
+    await _tts.setLanguage(locale);
+    await _tts.setRate(0.5);
+    await _tts.setVolume(1);
+    await _tts.setPitch(1.3);
   }
 
   // Initialize the route task, route parameters, and route result.
@@ -421,7 +405,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
       updateProgress,
     );
     _rerouteStartedSubscription = _routeTracker.onRerouteStarted.listen((_) {
-      _flutterTts.speak('Rerouting').ignore();
+      _tts.start('Rerouting').ignore();
       setState(() => _routeStatus = 'Rerouting');
     });
     _rerouteCompletedSubscription = _routeTracker.onRerouteCompleted.listen((
@@ -436,7 +420,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
     final nextDirection = voiceGuidance.text;
     if (nextDirection.isEmpty) return;
     _routeTracker.setSpeechEngineReady(() => false);
-    _flutterTts.speak(nextDirection).then((value) {
+    _tts.start(nextDirection).then((value) {
       _routeTracker.setSpeechEngineReady(() => true);
     }).ignore();
   }
@@ -531,7 +515,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
 
   // Stop the navigation.
   Future<void> stop() async {
-    await _flutterTts.stop();
+    await _tts.stop();
     // Stop the location display.
     _mapViewController.locationDisplay.autoPanMode =
         LocationDisplayAutoPanMode.off;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_syntax_view: ^4.1.7
-  flutter_tts: ^4.2.5
   glob: ^2.1.3
   go_router: ^17.3.0
   http: ^1.3.0
@@ -33,6 +32,7 @@ dependencies:
   share_plus: ^13.2.0
   shared_preferences: ^2.5.3
   simple_html_css: ^5.0.0
+  stts: ^1.3.3
   url_launcher: ^6.3.1
   webview_flutter: ^4.14.1
   xml: ^7.0.1


### PR DESCRIPTION
The `flutter_tts` package is behind on SPM support and Gradle support. Here we swap it out for the `stts` package, which has had all the modernization done already.