### PR TITLE
set speech rate to 1.0

### DIFF
--- a/lib/samples/navigate_route/navigate_route.dart
+++ b/lib/samples/navigate_route/navigate_route.dart
@@ -213,7 +213,7 @@ class _NavigateRouteState extends State<NavigateRoute> with SampleStateSupport {
 
     // Set the language based on the user's locale.
     await _tts.setLanguage(locale);
-    await _tts.setRate(0.5);
+    await _tts.setRate(1);
     await _tts.setVolume(1);
     await _tts.setPitch(1.3);
   }

--- a/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
+++ b/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
@@ -305,7 +305,7 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
 
     // Set the language based on the user's locale.
     await _tts.setLanguage(locale);
-    await _tts.setRate(0.5);
+    await _tts.setRate(1);
     await _tts.setVolume(1);
     await _tts.setPitch(1.3);
   }


### PR DESCRIPTION
With the previous `flutter_tts` package, we had been setting the speech rate to "0.5". With the new `stts` package, that's really slow. I'm not sure why the `stts` behaves differently than `flutter_tts` -- possibly `flutter_tts` was ignoring this value, or it was using some different scale. In any case, here we set this to "1.0" for `stts`. That brings us back to a normal-sounding rate.