### PR TITLE
Replace the "resource" tag with code that does the same thing

### DIFF
--- a/lib/models/downloadable_resource.dart
+++ b/lib/models/downloadable_resource.dart
@@ -23,11 +23,7 @@ import 'package:path/path.dart' as path;
 
 /// Represents a resource that can be downloaded for a sample.
 class DownloadableResource {
-  DownloadableResource({
-    required this.portal,
-    required this.itemId,
-    this.resource,
-  });
+  DownloadableResource({required this.portal, required this.itemId});
 
   factory DownloadableResource.fromJson(
     Map<String, dynamic> json,
@@ -36,18 +32,16 @@ class DownloadableResource {
     return DownloadableResource(
       portal: portal,
       itemId: json['itemId'] as String,
-      resource: json['resource'] as String?,
     );
   }
 
   final Portal portal;
   final String itemId;
-  final String? resource;
 
   PortalItem? _portalItem;
 
   Map<String, dynamic> toJson() {
-    return {'itemId': itemId, 'resource': resource};
+    return {'itemId': itemId};
   }
 
   /// Returns the PortalItem for this resource, from cache if available or else loaded from the network.

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -205,10 +205,8 @@ class OfflineData {
         final downloadedDir = r.downloadedDirectory();
 
         if (portalItem.name.toLowerCase().endsWith('.zip')) {
-          // For ZIP files, return the path to the resource inside the extracted directory.
-          return r.resource != null
-              ? path.join(downloadedDir.path, r.resource)
-              : downloadedDir.path;
+          // For ZIP files, return the extracted directory root.
+          return downloadedDir.path;
         } else {
           // For non-ZIP files, return the direct file path.
           return path.join(downloadedDir.path, portalItem.name);

--- a/lib/samples/add_feature_layers/README.metadata.json
+++ b/lib/samples/add_feature_layers/README.metadata.json
@@ -22,16 +22,13 @@
     ],
     "offline_data": [
       {
-        "itemId": "cb1b20748a9f4d128dad8a87244e3e37",
-        "resource": "LA_Trails.geodatabase"
+        "itemId": "cb1b20748a9f4d128dad8a87244e3e37"
       },
       {
-        "itemId": "68ec42517cdd439e81b036210483e8e7",
-        "resource": "AuroraCO.gpkg"
+        "itemId": "68ec42517cdd439e81b036210483e8e7"
       },
       {
-        "itemId": "15a7cbd3af1e47cfa5d2c6b93dc44fc2",
-        "resource": "ScottishWildlifeTrust_ReserveBoundaries_20201102.shp"
+        "itemId": "15a7cbd3af1e47cfa5d2c6b93dc44fc2"
       }
     ],
     "redirect_from": [],

--- a/lib/samples/add_feature_layers/add_feature_layers.dart
+++ b/lib/samples/add_feature_layers/add_feature_layers.dart
@@ -21,6 +21,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/token_challenger_handler.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 // Create an enumeration to define the feature layer sources.
 enum Source { url, portalItem, geodatabase, geopackage, shapefile }
@@ -80,9 +81,15 @@ class _AddFeatureLayersState extends State<AddFeatureLayers>
 
   void _initDownloadResources() {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    _dataSources[Source.geodatabase] = listPaths[0];
-    _dataSources[Source.geopackage] = listPaths[1];
-    _dataSources[Source.shapefile] = listPaths[2];
+    _dataSources[Source.geodatabase] = path.join(
+      listPaths[0],
+      'LA_Trails.geodatabase',
+    );
+    _dataSources[Source.geopackage] = path.join(listPaths[1], 'AuroraCO.gpkg');
+    _dataSources[Source.shapefile] = path.join(
+      listPaths[2],
+      'ScottishWildlifeTrust_ReserveBoundaries_20201102.shp',
+    );
   }
 
   @override

--- a/lib/samples/add_features_with_contingent_values/README.metadata.json
+++ b/lib/samples/add_features_with_contingent_values/README.metadata.json
@@ -25,8 +25,7 @@
             "resource": "ContingentValuesBirdNests.geodatabase"
         },
         {
-            "itemId": "b5106355f1634b8996e634c04b6a930a",
-            "resource": ""
+            "itemId": "b5106355f1634b8996e634c04b6a930a"
         }
     ],
     "redirect_from": [],

--- a/lib/samples/add_features_with_contingent_values/README.metadata.json
+++ b/lib/samples/add_features_with_contingent_values/README.metadata.json
@@ -21,8 +21,7 @@
     ],
     "offline_data": [
         {
-            "itemId": "e12b54ea799f4606a2712157cf9f6e41",
-            "resource": "ContingentValuesBirdNests.geodatabase"
+            "itemId": "e12b54ea799f4606a2712157cf9f6e41"
         },
         {
             "itemId": "b5106355f1634b8996e634c04b6a930a"

--- a/lib/samples/add_features_with_contingent_values/add_features_with_contingent_values.dart
+++ b/lib/samples/add_features_with_contingent_values/add_features_with_contingent_values.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class AddFeaturesWithContingentValues extends StatefulWidget {
   const AddFeaturesWithContingentValues({super.key});
@@ -110,7 +111,10 @@ class _AddFeaturesWithContingentValuesState
   // Reads the resolved file paths passed via GoRouter extras.
   void _initDownloadResources() {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    _geodatabasePath = listPaths[0];
+    _geodatabasePath = path.join(
+      listPaths[0],
+      'ContingentValuesBirdNests.geodatabase',
+    );
     _vtpkPath = listPaths[1];
   }
 

--- a/lib/samples/add_raster_from_file/README.metadata.json
+++ b/lib/samples/add_raster_from_file/README.metadata.json
@@ -17,8 +17,7 @@
     ],
     "offline_data": [
         {
-            "itemId": "7c4c679ab06a4df19dc497f577f111bd",
-            "resource": "raster-file/Shasta.tif"
+            "itemId": "7c4c679ab06a4df19dc497f577f111bd"
         }
     ],
     "redirect_from": [],

--- a/lib/samples/add_raster_from_file/add_raster_from_file.dart
+++ b/lib/samples/add_raster_from_file/add_raster_from_file.dart
@@ -83,7 +83,7 @@ class _AddRasterFromFileState extends State<AddRasterFromFile>
   Future<RasterLayer?> loadRasterLayerFromFile() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
     final shastaTifFile = File(
-      path.join(listPaths.first, 'raster-file/Shasta.tif'),
+      path.join(listPaths.first, 'raster-file', 'Shasta.tif'),
     );
 
     // Create a raster from the file URI.

--- a/lib/samples/add_raster_from_file/add_raster_from_file.dart
+++ b/lib/samples/add_raster_from_file/add_raster_from_file.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class AddRasterFromFile extends StatefulWidget {
   const AddRasterFromFile({super.key});
@@ -81,7 +82,9 @@ class _AddRasterFromFileState extends State<AddRasterFromFile>
 
   Future<RasterLayer?> loadRasterLayerFromFile() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final shastaTifFile = File(listPaths.first);
+    final shastaTifFile = File(
+      path.join(listPaths.first, 'raster-file/Shasta.tif'),
+    );
 
     // Create a raster from the file URI.
     final raster = Raster.withFileUri(shastaTifFile.uri);

--- a/lib/samples/animate_3d_graphic/README.metadata.json
+++ b/lib/samples/animate_3d_graphic/README.metadata.json
@@ -26,8 +26,7 @@
         "SurfacePlacement"
     ],
     "offline_data": [{
-        "itemId": "681d6f7694644709a7c830ec57a2d72b",
-        "resource": "Bristol.dae"
+        "itemId": "681d6f7694644709a7c830ec57a2d72b"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
+++ b/lib/samples/animate_3d_graphic/animate_3d_graphic.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class Animate3dGraphic extends StatefulWidget {
   const Animate3dGraphic({super.key});
@@ -274,7 +275,7 @@ class _Animate3dGraphicState extends State<Animate3dGraphic>
     );
 
     final listPaths = GoRouterState.of(context).extra! as List<String>;
-    final planeModelPath = listPaths.first;
+    final planeModelPath = path.join(listPaths.first, 'Bristol.dae');
 
     // Define the plane symbol.
     final planeSymbol = ModelSceneSymbol.withUri(

--- a/lib/samples/animate_images_with_image_overlay/README.metadata.json
+++ b/lib/samples/animate_images_with_image_overlay/README.metadata.json
@@ -19,8 +19,7 @@
         "ImageOverlay"
     ],
     "offline_data": [{
-        "itemId": "9465e8c02b294c69bdb42de056a23ab1",
-        "resource": "PacificSouthWest"
+        "itemId": "9465e8c02b294c69bdb42de056a23ab1"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
+++ b/lib/samples/animate_images_with_image_overlay/animate_images_with_image_overlay.dart
@@ -21,6 +21,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class AnimateImagesWithImageOverlay extends StatefulWidget {
   const AnimateImagesWithImageOverlay({super.key});
@@ -261,7 +262,9 @@ class _AnimateImagesWithImageOverlayState
   Future<void> initImageFrames() async {
     final listPaths = GoRouterState.of(context).extra! as List<String>;
     // The sample data contains images of the Pacific South West region.
-    final directory = Directory.fromUri(Uri.parse(listPaths.first));
+    final directory = Directory.fromUri(
+      Uri.file(path.join(listPaths.first, 'PacificSouthWest')),
+    );
 
     // Get a list of all PNG image files in the extracted directory.
     _imageFileList = directory

--- a/lib/samples/apply_colormap_renderer_to_raster/README.metadata.json
+++ b/lib/samples/apply_colormap_renderer_to_raster/README.metadata.json
@@ -2,8 +2,7 @@
     "category": "Layers",
     "description": "Apply a colormap renderer to a raster.",
     "offline_data": [{
-        "itemId": "cc68728b5904403ba637e1f1cd2995ae",
-        "resource": "ShastaBW.tif"
+        "itemId": "cc68728b5904403ba637e1f1cd2995ae"
     }],
     "ignore": false,
     "images": [

--- a/lib/samples/apply_colormap_renderer_to_raster/apply_colormap_renderer_to_raster.dart
+++ b/lib/samples/apply_colormap_renderer_to_raster/apply_colormap_renderer_to_raster.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ApplyColormapRendererToRaster extends StatefulWidget {
   const ApplyColormapRendererToRaster({super.key});
@@ -59,7 +60,7 @@ class _ApplyColormapRendererToRasterState
 
     // Get the application documents directory.
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final mspkFile = File(listPaths.first);
+    final mspkFile = File(path.join(listPaths.first, 'ShastaBW.tif'));
 
     // Create a Raster from the local tif file.
     final raster = Raster.withFileUri(mspkFile.uri);

--- a/lib/samples/apply_colormap_renderer_to_raster/apply_colormap_renderer_to_raster.dart
+++ b/lib/samples/apply_colormap_renderer_to_raster/apply_colormap_renderer_to_raster.dart
@@ -60,10 +60,10 @@ class _ApplyColormapRendererToRasterState
 
     // Get the application documents directory.
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final mspkFile = File(path.join(listPaths.first, 'ShastaBW.tif'));
+    final tifFile = File(path.join(listPaths.first, 'ShastaBW.tif'));
 
     // Create a Raster from the local tif file.
-    final raster = Raster.withFileUri(mspkFile.uri);
+    final raster = Raster.withFileUri(tifFile.uri);
 
     // Create a Raster Layer.
     final rasterLayer = RasterLayer.withRaster(raster);

--- a/lib/samples/apply_dictionary_renderer_to_feature_layer/README.metadata.json
+++ b/lib/samples/apply_dictionary_renderer_to_feature_layer/README.metadata.json
@@ -6,8 +6,7 @@
             "itemId": "c78b149a1d52414682c86a5feeb13d30"
         },
         {
-            "itemId": "e0d41b4b409a49a5a7ba11939d8535dc",
-            "resource": "militaryoverlay.geodatabase"
+            "itemId": "e0d41b4b409a49a5a7ba11939d8535dc"
         }
     ],
     "ignore": false,

--- a/lib/samples/apply_dictionary_renderer_to_feature_layer/apply_dictionary_renderer_to_feature_layer.dart
+++ b/lib/samples/apply_dictionary_renderer_to_feature_layer/apply_dictionary_renderer_to_feature_layer.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ApplyDictionaryRendererToFeatureLayer extends StatefulWidget {
   const ApplyDictionaryRendererToFeatureLayer({super.key});
@@ -49,7 +50,9 @@ class _ApplyDictionaryRendererToFeatureLayerState
     // Create file references for the dictionary style and geodatabase.
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
     final styleFile = File(listPaths.first);
-    final geodatabaseFile = File(listPaths.last);
+    final geodatabaseFile = File(
+      path.join(listPaths.last, 'militaryoverlay.geodatabase'),
+    );
 
     // Create the map and assign it to the map view controller.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);

--- a/lib/samples/apply_dictionary_renderer_to_graphics_overlay/README.metadata.json
+++ b/lib/samples/apply_dictionary_renderer_to_graphics_overlay/README.metadata.json
@@ -3,8 +3,7 @@
     "description": "Create graphics from an XML file with key-value pairs for each graphic, and display the military symbols using a MIL-STD-2525D web style in 3D.",
     "offline_data": [
         {
-            "itemId": "8776cfc26eed4485a03de6316826384c",
-            "resource": "Mil2525DMessages.xml"
+            "itemId": "8776cfc26eed4485a03de6316826384c"
         }
     ],
     "ignore": false,

--- a/lib/samples/apply_dictionary_renderer_to_graphics_overlay/apply_dictionary_renderer_to_graphics_overlay.dart
+++ b/lib/samples/apply_dictionary_renderer_to_graphics_overlay/apply_dictionary_renderer_to_graphics_overlay.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 import 'package:xml/xml.dart';
 
 class ApplyDictionaryRendererToGraphicsOverlay extends StatefulWidget {
@@ -114,7 +115,9 @@ class _ApplyDictionaryRendererToGraphicsOverlayState
   Future<List<Graphic>> generateMessageGraphics() async {
     // Create file reference for the MIL-STD-2525D XML File.
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final mil2525XMLFile = File(listPaths.first);
+    final mil2525XMLFile = File(
+      path.join(listPaths.first, 'Mil2525DMessages.xml'),
+    );
 
     // Read the XML as a string and parse it into a list of Message objects.
     final xmlString = await mil2525XMLFile.readAsString();

--- a/lib/samples/apply_function_to_raster_from_file/README.metadata.json
+++ b/lib/samples/apply_function_to_raster_from_file/README.metadata.json
@@ -3,8 +3,7 @@
   "description": "Apply a raster function to a local raster file and display the output with a raster layer.",
   "offline_data": [
     {
-      "itemId": "b051f5c3e01048f3bf11c59b41507896",
-      "resource": "Shasta_Elevation.tif"
+      "itemId": "b051f5c3e01048f3bf11c59b41507896"
     },
     {
       "itemId": "5356dbf91788474493467519e268cf87"

--- a/lib/samples/apply_function_to_raster_from_file/apply_function_to_raster_from_file.dart
+++ b/lib/samples/apply_function_to_raster_from_file/apply_function_to_raster_from_file.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ApplyFunctionToRasterFromFile extends StatefulWidget {
   const ApplyFunctionToRasterFromFile({super.key});
@@ -79,7 +80,9 @@ class _ApplyFunctionToRasterFromFileState
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
 
     // Create and load a Raster from the local tif file.
-    final shastaElevationRaster = Raster.withFileUri(Uri.file(listPaths[0]));
+    final shastaElevationRaster = Raster.withFileUri(
+      Uri.file(path.join(listPaths[0], 'Shasta_Elevation.tif')),
+    );
     await shastaElevationRaster.load();
     // Load the color configuration from the JSON file located in the app's directory.
     final file = File(listPaths[1]);

--- a/lib/samples/apply_scheduled_updates_to_preplanned_map_area/README.metadata.json
+++ b/lib/samples/apply_scheduled_updates_to_preplanned_map_area/README.metadata.json
@@ -3,8 +3,7 @@
     "description": "Apply scheduled updates to a downloaded preplanned map area.",
     "offline_data": [
         {
-            "itemId": "740b663bff5e4198b9b6674af93f638a",
-            "resource": ""
+            "itemId": "740b663bff5e4198b9b6674af93f638a"
         }
     ],
     "ignore": false,

--- a/lib/samples/apply_symbology_to_shapefile/README.metadata.json
+++ b/lib/samples/apply_symbology_to_shapefile/README.metadata.json
@@ -2,8 +2,7 @@
     "category": "Visualization",
     "description": "Display a shapefile with custom symbology.",
      "offline_data": [{
-        "itemId": "d98b3e5293834c5f852f13c569930caa",
-        "resource": "Subdivisions.shp"
+        "itemId": "d98b3e5293834c5f852f13c569930caa"
     }],
     "ignore": false,
     "images": [

--- a/lib/samples/apply_symbology_to_shapefile/apply_symbology_to_shapefile.dart
+++ b/lib/samples/apply_symbology_to_shapefile/apply_symbology_to_shapefile.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ApplySymbologyToShapefile extends StatefulWidget {
   const ApplySymbologyToShapefile({super.key});
@@ -92,7 +93,7 @@ class _ApplySymbologyToShapefileState extends State<ApplySymbologyToShapefile>
 
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
     // Get the Shapefile from the download resource.
-    final shapefile = File(listPaths.first);
+    final shapefile = File(path.join(listPaths.first, 'Subdivisions.shp'));
 
     // Create a feature table from the Shapefile URI.
     final shapefileFeatureTable = ShapefileFeatureTable.withFileUri(

--- a/lib/samples/change_camera_controller/README.metadata.json
+++ b/lib/samples/change_camera_controller/README.metadata.json
@@ -3,8 +3,7 @@
     "description": "Control the behavior of the camera in a scene.",
     "offline_data": [
         {
-            "itemId": "681d6f7694644709a7c830ec57a2d72b",
-            "resource": "Bristol.dae"
+            "itemId": "681d6f7694644709a7c830ec57a2d72b"
         }
     ],
     "ignore": false,

--- a/lib/samples/change_camera_controller/change_camera_controller.dart
+++ b/lib/samples/change_camera_controller/change_camera_controller.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ChangeCameraController extends StatefulWidget {
   const ChangeCameraController({super.key});
@@ -203,7 +204,7 @@ class _ChangeCameraControllerState extends State<ChangeCameraController>
 
   Future<Graphic> _setupPlaneGraphic() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final bristolFile = File(listPaths.first);
+    final bristolFile = File(path.join(listPaths.first, 'Bristol.dae'));
 
     // Define the plane's position.
     final planePosition = ArcGISPoint(

--- a/lib/samples/configure_electronic_navigational_charts/README.metadata.json
+++ b/lib/samples/configure_electronic_navigational_charts/README.metadata.json
@@ -31,12 +31,10 @@
     ],
     "offline_data": [
         {
-            "itemId": "5028bf3513ff4c38b28822d010a4937c",
-            "resource": "hydrography"
+            "itemId": "5028bf3513ff4c38b28822d010a4937c"
         },
         {
-            "itemId": "9d2987a825c646468b3ce7512fb76e2d",
-            "resource": "ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031"
+            "itemId": "9d2987a825c646468b3ce7512fb76e2d"
         }
     ],
     "redirect_from": [],

--- a/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
+++ b/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ConfigureElectronicNavigationalCharts extends StatefulWidget {
   const ConfigureElectronicNavigationalCharts({super.key});
@@ -103,8 +104,15 @@ class _ConfigureElectronicNavigationalChartsState
   Future<void> onMapViewReady() async {
     try {
       final downloadPaths = GoRouter.of(context).state.extra! as List<String>;
-      final hydrographyDirectory = Directory(downloadPaths[0]);
-      final exchangeSetFile = File(downloadPaths[1]);
+      final hydrographyDirectory = Directory(
+        path.join(downloadPaths[0], 'hydrography'),
+      );
+      final exchangeSetFile = File(
+        path.join(
+          downloadPaths[1],
+          'ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031',
+        ),
+      );
 
       // Configure the ENC resource directory to point to the downloaded hydrography data, and prepare a temp directory.
       final environmentSettings = EncLayer.getEnvironmentSettings();

--- a/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
+++ b/lib/samples/configure_electronic_navigational_charts/configure_electronic_navigational_charts.dart
@@ -110,7 +110,9 @@ class _ConfigureElectronicNavigationalChartsState
       final exchangeSetFile = File(
         path.join(
           downloadPaths[1],
-          'ExchangeSetwithoutUpdates/ENC_ROOT/CATALOG.031',
+          'ExchangeSetwithoutUpdates',
+          'ENC_ROOT',
+          'CATALOG.031',
         ),
       );
 

--- a/lib/samples/edit_geodatabase_with_transactions/README.metadata.json
+++ b/lib/samples/edit_geodatabase_with_transactions/README.metadata.json
@@ -7,8 +7,7 @@
     ],
     "offline_data": [
         {
-            "itemId": "43809fd639f242fd8045ecbafd61a579",
-            "resource": "SaveTheBay.geodatabase"
+            "itemId": "43809fd639f242fd8045ecbafd61a579"
         }
     ],
 

--- a/lib/samples/edit_geodatabase_with_transactions/edit_geodatabase_with_transactions.dart
+++ b/lib/samples/edit_geodatabase_with_transactions/edit_geodatabase_with_transactions.dart
@@ -17,6 +17,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class EditGeodatabaseWithTransactions extends StatefulWidget {
   const EditGeodatabaseWithTransactions({super.key});
@@ -72,7 +73,7 @@ class _EditGeodatabaseWithTransactionsState
   // Get the downloaded geodatabase path.
   void _initDownloadResources() {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    _saveTheBayPath = listPaths.first;
+    _saveTheBayPath = path.join(listPaths.first, 'SaveTheBay.geodatabase');
   }
 
   @override

--- a/lib/samples/identify_raster_cell/README.metadata.json
+++ b/lib/samples/identify_raster_cell/README.metadata.json
@@ -23,8 +23,7 @@
         "RasterLayer"
     ],
     "offline_data": [{
-        "itemId": "b5f977c78ec74b3a8857ca86d1d9b318",
-        "resource": "SA_EVI_8Day_03May20.tif"
+        "itemId": "b5f977c78ec74b3a8857ca86d1d9b318"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/identify_raster_cell/identify_raster_cell.dart
+++ b/lib/samples/identify_raster_cell/identify_raster_cell.dart
@@ -17,6 +17,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class IdentifyRasterCell extends StatefulWidget {
   const IdentifyRasterCell({super.key});
@@ -109,7 +110,9 @@ class _IdentifyRasterCellState extends State<IdentifyRasterCell>
   Future<void> loadRasterLayer() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
     // Create a Raster from the local tif file.
-    final raster = Raster.withFileUri(Uri.file(listPaths.first));
+    final raster = Raster.withFileUri(
+      Uri.file(path.join(listPaths.first, 'SA_EVI_8Day_03May20.tif')),
+    );
     // Create a Raster Layer.
     _rasterLayer = RasterLayer.withRaster(raster);
     // Load the Raster Layer.

--- a/lib/samples/navigate_route_with_rerouting/README.metadata.json
+++ b/lib/samples/navigate_route_with_rerouting/README.metadata.json
@@ -26,12 +26,10 @@
     ],
     "offline_data": [
       {
-        "itemId": "df193653ed39449195af0c9725701dca",
-        "resource": "sandiego.geodatabase"
+        "itemId": "df193653ed39449195af0c9725701dca"
       },
       {
-        "itemId": "4caec8c55ea2463982f1af7d9611b8d5",
-        "resource": "SanDiegoTourPath.json"
+        "itemId": "4caec8c55ea2463982f1af7d9611b8d5"
       }
     ],
     "redirect_from": [],

--- a/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
+++ b/lib/samples/navigate_route_with_rerouting/navigate_route_with_rerouting.dart
@@ -20,6 +20,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 import 'package:stts/stts.dart';
 
 class NavigateRouteWithRerouting extends StatefulWidget {
@@ -107,9 +108,11 @@ class _NavigateRouteWithReroutingState extends State<NavigateRouteWithRerouting>
   void initState() {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
     // Store the path of the downloaded geodatabase.
-    _geodatabasePath = listPaths[0];
+    _geodatabasePath = path.join(listPaths[0], 'sandiego.geodatabase');
     // Create a simulated location data source using the downloaded JSON file.
-    _simulatedLocationDataSource = getLocationDataSource(listPaths[1]);
+    _simulatedLocationDataSource = getLocationDataSource(
+      path.join(listPaths[1], 'SanDiegoTourPath.json'),
+    );
 
     super.initState();
   }

--- a/lib/samples/query_dynamic_entities/README.metadata.json
+++ b/lib/samples/query_dynamic_entities/README.metadata.json
@@ -24,8 +24,7 @@
         "DynamicEntityQueryResult"
     ],
     "offline_data": [{
-        "itemId": "c78e297e99ad4572a48cdcd0b54bed30",
-        "resource": "phx_air_traffic.json"
+        "itemId": "c78e297e99ad4572a48cdcd0b54bed30"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/query_dynamic_entities/query_dynamic_entities.dart
+++ b/lib/samples/query_dynamic_entities/query_dynamic_entities.dart
@@ -22,6 +22,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class QueryDynamicEntities extends StatefulWidget {
   const QueryDynamicEntities({super.key});
@@ -167,7 +168,9 @@ class _QueryDynamicEntitiesState extends State<QueryDynamicEntities>
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
 
     // Create a custom data source that streams PHX air traffic observations.
-    final provider = _PhxAirTrafficProvider(localJsonPath: listPaths.first);
+    final provider = _PhxAirTrafficProvider(
+      localJsonPath: path.join(listPaths.first, 'phx_air_traffic.json'),
+    );
     _dataSource = CustomDynamicEntityDataSource(provider);
 
     // Create a dynamic entity later from the custom data source.

--- a/lib/samples/show_device_location_with_nmea_data_sources/README.metadata.json
+++ b/lib/samples/show_device_location_with_nmea_data_sources/README.metadata.json
@@ -19,8 +19,7 @@
         "NmeaSatelliteInfo"
     ],
      "offline_data": [{
-        "itemId": "d5bad9f4fee9483791e405880fb466da",
-        "resource": "Redlands.nmea"
+        "itemId": "d5bad9f4fee9483791e405880fb466da"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
+++ b/lib/samples/show_device_location_with_nmea_data_sources/show_device_location_with_nmea_data_sources.dart
@@ -21,6 +21,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ShowDeviceLocationWithNmeaDataSources extends StatefulWidget {
   const ShowDeviceLocationWithNmeaDataSources({super.key});
@@ -219,7 +220,7 @@ class _ShowDeviceLocationWithNmeaDataSourcesState
   Future<List<String>> _loadNmeaFile() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
 
-    final nmeaFile = File(listPaths.first);
+    final nmeaFile = File(path.join(listPaths.first, 'Redlands.nmea'));
 
     // Read and return the file as a list of String lines.
     return nmeaFile.readAsLines();

--- a/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/README.metadata.json
+++ b/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/README.metadata.json
@@ -22,8 +22,7 @@
         "OrbitGeoElementCameraController"
     ],
     "offline_data": [{
-        "itemId": "07d62a792ab6496d9b772a24efea45d0",
-        "resource": "bradle.3ds"
+        "itemId": "07d62a792ab6496d9b772a24efea45d0"
     }],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/show_exploratory_viewshed_from_geoelement_in_scene.dart
+++ b/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/show_exploratory_viewshed_from_geoelement_in_scene.dart
@@ -19,6 +19,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class ShowExploratoryViewshedFromGeoelementInScene extends StatefulWidget {
   const ShowExploratoryViewshedFromGeoelementInScene({super.key});
@@ -202,7 +203,7 @@ class _ShowExploratoryViewshedFromGeoelementInSceneState
   // Loads the 3D tank model from local sample data and returns it as a Graphic.
   Future<Graphic> _loadTankGraphic() async {
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final tankModelPath = listPaths.first;
+    final tankModelPath = path.join(listPaths.first, 'bradle.3ds');
 
     // Define the tank symbol.
     final tankSymbol =

--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/README.metadata.json
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/README.metadata.json
@@ -30,8 +30,7 @@
     ],
     "offline_data": [
       {
-        "itemId": "0fd3a39660d54c12b05d5f81f207dffd",
-        "resource": "NapervilleGasUtilities.geodatabase"
+        "itemId": "0fd3a39660d54c12b05d5f81f207dffd"
       }
     ],
     "redirect_from": [],

--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/snap_geometry_edits_with_utility_network_rules.dart
@@ -22,6 +22,7 @@ import 'package:arcgis_maps_sdk_flutter_samples/common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as path;
 
 class SnapGeometryEditsWithUtilityNetworkRules extends StatefulWidget {
   const SnapGeometryEditsWithUtilityNetworkRules({super.key});
@@ -183,7 +184,9 @@ class _SnapGeometryEditsWithUtilityNetworkRulesState
   Future<void> onMapViewReady() async {
     // Download the Naperville utility network geodatabase.
     final listPaths = GoRouter.of(context).state.extra! as List<String>;
-    final geodatabaseFile = File(listPaths.first);
+    final geodatabaseFile = File(
+      path.join(listPaths.first, 'NapervilleGasUtilities.geodatabase'),
+    );
 
     // Configure the map, centered on Naperville, IL.
     final map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISStreetsNight);


### PR DESCRIPTION
The broad goal here is to reduce the "offline_data" section of the JSON file down to be nothing more than the list of PortalItem itemId's. That will make it easier to prepare the README.metadata.json file for new samples by either human or AI.

The next step towards that goal is to replace the "resource" values in the JSON files. Previously, the "resource" value was used to designate a specific file out of a ZIP archive. Now, the `downloadedFilePaths()` method will simply return the path to the folder where the ZIP archive was extracted, and then it is up to individual samples to prepare the path to the target file.

Most of this PR is making this change for every sample that had a "resource" value. An AI prompt was used to do the migration. Aside from the individual samples, the other changes are to remove the code that parses the "resource" value (downloadable_resource.dart, offline_data.dart).