### PR TITLE
convert offline_data to a simple list of itemId's

### DIFF
--- a/lib/models/downloadable_resource.dart
+++ b/lib/models/downloadable_resource.dart
@@ -25,24 +25,10 @@ import 'package:path/path.dart' as path;
 class DownloadableResource {
   DownloadableResource({required this.portal, required this.itemId});
 
-  factory DownloadableResource.fromJson(
-    Map<String, dynamic> json,
-    Portal portal,
-  ) {
-    return DownloadableResource(
-      portal: portal,
-      itemId: json['itemId'] as String,
-    );
-  }
-
   final Portal portal;
   final String itemId;
 
   PortalItem? _portalItem;
-
-  Map<String, dynamic> toJson() {
-    return {'itemId': itemId};
-  }
 
   /// Returns the PortalItem for this resource, from cache if available or else loaded from the network.
   Future<PortalItem> cachedPortalItem() async {

--- a/lib/models/offline_data.dart
+++ b/lib/models/offline_data.dart
@@ -73,8 +73,8 @@ class OfflineData {
   /// Creates an [OfflineData] instance from a JSON list of downloadable resources.
   OfflineData.fromJson(List<dynamic> json, Portal portal) {
     _downloadableResources = json
-        .whereType<Map<String, dynamic>>()
-        .map((json) => DownloadableResource.fromJson(json, portal))
+        .whereType<String>()
+        .map((itemId) => DownloadableResource(portal: portal, itemId: itemId))
         .toList(growable: false);
   }
 

--- a/lib/samples/add_feature_layers/README.metadata.json
+++ b/lib/samples/add_feature_layers/README.metadata.json
@@ -21,15 +21,9 @@
         "ShapefileFeatureTable"
     ],
     "offline_data": [
-      {
-        "itemId": "cb1b20748a9f4d128dad8a87244e3e37"
-      },
-      {
-        "itemId": "68ec42517cdd439e81b036210483e8e7"
-      },
-      {
-        "itemId": "15a7cbd3af1e47cfa5d2c6b93dc44fc2"
-      }
+      "cb1b20748a9f4d128dad8a87244e3e37",
+      "68ec42517cdd439e81b036210483e8e7",
+      "15a7cbd3af1e47cfa5d2c6b93dc44fc2"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/add_features_with_contingent_values/README.metadata.json
+++ b/lib/samples/add_features_with_contingent_values/README.metadata.json
@@ -20,12 +20,8 @@
         "ContingentValuesResult"
     ],
     "offline_data": [
-        {
-            "itemId": "e12b54ea799f4606a2712157cf9f6e41"
-        },
-        {
-            "itemId": "b5106355f1634b8996e634c04b6a930a"
-        }
+        "e12b54ea799f4606a2712157cf9f6e41",
+        "b5106355f1634b8996e634c04b6a930a"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/add_point_cloud_layer_from_file/README.metadata.json
+++ b/lib/samples/add_point_cloud_layer_from_file/README.metadata.json
@@ -12,9 +12,7 @@
         "PointCloudLayer"
     ],
     "offline_data": [
-        {
-            "itemId": "34da965ca51d4c68aa9b3a38edb29e00"
-        }
+        "34da965ca51d4c68aa9b3a38edb29e00"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/add_raster_from_file/README.metadata.json
+++ b/lib/samples/add_raster_from_file/README.metadata.json
@@ -16,9 +16,7 @@
         "RasterLayer"
     ],
     "offline_data": [
-        {
-            "itemId": "7c4c679ab06a4df19dc497f577f111bd"
-        }
+        "7c4c679ab06a4df19dc497f577f111bd"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/add_tiled_layer_as_basemap/README.metadata.json
+++ b/lib/samples/add_tiled_layer_as_basemap/README.metadata.json
@@ -15,9 +15,7 @@
         "Basemap",
         "TileCache"
     ],
-    "offline_data": [{
-        "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5"
-    }],
+    "offline_data": ["e4a398afe9a945f3b0f4dca1e4faccb5"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISMap",

--- a/lib/samples/add_vector_tiled_layer_from_custom_style/README.metadata.json
+++ b/lib/samples/add_vector_tiled_layer_from_custom_style/README.metadata.json
@@ -20,9 +20,7 @@
         "VectorTileCache"
     ],
     "offline_data": [
-        {
-            "itemId": "f4b742a57af344988b02227e2824ca5f"
-        }
+        "f4b742a57af344988b02227e2824ca5f"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/animate_3d_graphic/README.metadata.json
+++ b/lib/samples/animate_3d_graphic/README.metadata.json
@@ -25,9 +25,7 @@
         "SceneProperties",
         "SurfacePlacement"
     ],
-    "offline_data": [{
-        "itemId": "681d6f7694644709a7c830ec57a2d72b"
-    }],
+    "offline_data": ["681d6f7694644709a7c830ec57a2d72b"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISScene",

--- a/lib/samples/animate_images_with_image_overlay/README.metadata.json
+++ b/lib/samples/animate_images_with_image_overlay/README.metadata.json
@@ -18,9 +18,7 @@
         "ImageFrame",
         "ImageOverlay"
     ],
-    "offline_data": [{
-        "itemId": "9465e8c02b294c69bdb42de056a23ab1"
-    }],
+    "offline_data": ["9465e8c02b294c69bdb42de056a23ab1"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISSceneViewController",

--- a/lib/samples/apply_colormap_renderer_to_raster/README.metadata.json
+++ b/lib/samples/apply_colormap_renderer_to_raster/README.metadata.json
@@ -1,9 +1,7 @@
 {
     "category": "Layers",
     "description": "Apply a colormap renderer to a raster.",
-    "offline_data": [{
-        "itemId": "cc68728b5904403ba637e1f1cd2995ae"
-    }],
+    "offline_data": ["cc68728b5904403ba637e1f1cd2995ae"],
     "ignore": false,
     "images": [
         "apply_colormap_renderer_to_raster.png"

--- a/lib/samples/apply_dictionary_renderer_to_feature_layer/README.metadata.json
+++ b/lib/samples/apply_dictionary_renderer_to_feature_layer/README.metadata.json
@@ -2,12 +2,8 @@
     "category": "Visualization",
     "description": "Convert features into graphics to show them with mil2525d symbols.",
     "offline_data": [
-        {
-            "itemId": "c78b149a1d52414682c86a5feeb13d30"
-        },
-        {
-            "itemId": "e0d41b4b409a49a5a7ba11939d8535dc"
-        }
+        "c78b149a1d52414682c86a5feeb13d30",
+        "e0d41b4b409a49a5a7ba11939d8535dc"
     ],
     "ignore": false,
     "images": [

--- a/lib/samples/apply_dictionary_renderer_to_graphics_overlay/README.metadata.json
+++ b/lib/samples/apply_dictionary_renderer_to_graphics_overlay/README.metadata.json
@@ -2,9 +2,7 @@
     "category": "Visualization",
     "description": "Create graphics from an XML file with key-value pairs for each graphic, and display the military symbols using a MIL-STD-2525D web style in 3D.",
     "offline_data": [
-        {
-            "itemId": "8776cfc26eed4485a03de6316826384c"
-        }
+        "8776cfc26eed4485a03de6316826384c"
     ],
     "ignore": false,
     "images": [

--- a/lib/samples/apply_function_to_raster_from_file/README.metadata.json
+++ b/lib/samples/apply_function_to_raster_from_file/README.metadata.json
@@ -2,12 +2,8 @@
   "category": "Layers",
   "description": "Apply a raster function to a local raster file and display the output with a raster layer.",
   "offline_data": [
-    {
-      "itemId": "b051f5c3e01048f3bf11c59b41507896"
-    },
-    {
-      "itemId": "5356dbf91788474493467519e268cf87"
-    }
+    "b051f5c3e01048f3bf11c59b41507896",
+    "5356dbf91788474493467519e268cf87"
   ],
   "ignore": false,
   "images": [

--- a/lib/samples/apply_map_algebra/README.metadata.json
+++ b/lib/samples/apply_map_algebra/README.metadata.json
@@ -22,9 +22,7 @@
         "StretchRenderer"
     ],
     "offline_data": [
-        {
-            "itemId": "aa97788593e34a32bcaae33947fdc271"
-        }
+        "aa97788593e34a32bcaae33947fdc271"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/apply_scheduled_updates_to_preplanned_map_area/README.metadata.json
+++ b/lib/samples/apply_scheduled_updates_to_preplanned_map_area/README.metadata.json
@@ -2,9 +2,7 @@
     "category": "Edit and Manage Data",
     "description": "Apply scheduled updates to a downloaded preplanned map area.",
     "offline_data": [
-        {
-            "itemId": "740b663bff5e4198b9b6674af93f638a"
-        }
+        "740b663bff5e4198b9b6674af93f638a"
     ],
     "ignore": false,
     "images": [

--- a/lib/samples/apply_symbology_to_shapefile/README.metadata.json
+++ b/lib/samples/apply_symbology_to_shapefile/README.metadata.json
@@ -1,9 +1,7 @@
 {
     "category": "Visualization",
     "description": "Display a shapefile with custom symbology.",
-     "offline_data": [{
-        "itemId": "d98b3e5293834c5f852f13c569930caa"
-    }],
+     "offline_data": ["d98b3e5293834c5f852f13c569930caa"],
     "ignore": false,
     "images": [
         "apply_symbology_to_shapefile.png"

--- a/lib/samples/change_camera_controller/README.metadata.json
+++ b/lib/samples/change_camera_controller/README.metadata.json
@@ -2,9 +2,7 @@
     "category": "Scenes",
     "description": "Control the behavior of the camera in a scene.",
     "offline_data": [
-        {
-            "itemId": "681d6f7694644709a7c830ec57a2d72b"
-        }
+        "681d6f7694644709a7c830ec57a2d72b"
     ],
     "ignore": false,
     "images": [

--- a/lib/samples/configure_electronic_navigational_charts/README.metadata.json
+++ b/lib/samples/configure_electronic_navigational_charts/README.metadata.json
@@ -30,12 +30,8 @@
         "IdentifyLayerResult"
     ],
     "offline_data": [
-        {
-            "itemId": "5028bf3513ff4c38b28822d010a4937c"
-        },
-        {
-            "itemId": "9d2987a825c646468b3ce7512fb76e2d"
-        }
+        "5028bf3513ff4c38b28822d010a4937c",
+        "9d2987a825c646468b3ce7512fb76e2d"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/control_annotation_sublayer_visibility/README.metadata.json
+++ b/lib/samples/control_annotation_sublayer_visibility/README.metadata.json
@@ -15,9 +15,7 @@
     "AnnotationSublayer",
     "LayerContent"
   ],
-  "offline_data": [{
-      "itemId": "b87307dcfb26411eb2e92e1627cb615b"
-  }],
+  "offline_data": ["b87307dcfb26411eb2e92e1627cb615b"],
   "redirect_from": [],
   "relevant_apis": [
     "AnnotationLayer",

--- a/lib/samples/display_dimensions/README.metadata.json
+++ b/lib/samples/display_dimensions/README.metadata.json
@@ -17,9 +17,7 @@
         "DimensionLayer",
         "MobileMapPackage"
     ],
-    "offline_data": [{
-        "itemId": "f5ff6f5556a945bca87ca513b8729a1e"
-    }],
+    "offline_data": ["f5ff6f5556a945bca87ca513b8729a1e"],
     "redirect_from": [],
     "relevant_apis": [
         "DimensionLayer",

--- a/lib/samples/display_map_from_mobile_map_package/README.metadata.json
+++ b/lib/samples/display_map_from_mobile_map_package/README.metadata.json
@@ -12,9 +12,7 @@
         "ArcGISMapView",
         "MobileMapPackage"
     ],
-    "offline_data": [{
-        "itemId": "e1f3a7254cb845b09450f54937c16061"
-    }],
+    "offline_data": ["e1f3a7254cb845b09450f54937c16061"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISMapView",

--- a/lib/samples/display_scene_from_mobile_scene_package/README.metadata.json
+++ b/lib/samples/display_scene_from_mobile_scene_package/README.metadata.json
@@ -11,9 +11,7 @@
         "ArcGISSceneView",
         "MobileScenePackage"
     ],
-    "offline_data": [{
-        "itemId": "7dd2f97bb007466ea939160d0de96a9d"
-    }],
+    "offline_data": ["7dd2f97bb007466ea939160d0de96a9d"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISSceneView",

--- a/lib/samples/edit_geodatabase_with_transactions/README.metadata.json
+++ b/lib/samples/edit_geodatabase_with_transactions/README.metadata.json
@@ -6,9 +6,7 @@
         "edit_geodatabase_with_transactions.png"
     ],
     "offline_data": [
-        {
-            "itemId": "43809fd639f242fd8045ecbafd61a579"
-        }
+        "43809fd639f242fd8045ecbafd61a579"
     ],
 
     "keywords": [

--- a/lib/samples/find_route_in_mobile_map_package/README.metadata.json
+++ b/lib/samples/find_route_in_mobile_map_package/README.metadata.json
@@ -26,12 +26,8 @@
         "TransportationNetworkDataset"
     ],
     "offline_data": [
-      {
-        "itemId": "e1f3a7254cb845b09450f54937c16061"
-      },
-      {
-        "itemId": "260eb6535c824209964cf281766ebe43"
-      }
+      "e1f3a7254cb845b09450f54937c16061",
+      "260eb6535c824209964cf281766ebe43"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/generate_geodatabase_replica_from_feature_service/README.metadata.json
+++ b/lib/samples/generate_geodatabase_replica_from_feature_service/README.metadata.json
@@ -16,9 +16,7 @@
         "Geodatabase",
         "GeodatabaseSyncTask"
     ],
-    "offline_data": [{
-        "itemId": "e4a398afe9a945f3b0f4dca1e4faccb5"
-    }],
+    "offline_data": ["e4a398afe9a945f3b0f4dca1e4faccb5"],
     "redirect_from": [],
     "relevant_apis": [
         "GenerateGeodatabaseJob",

--- a/lib/samples/identify_raster_cell/README.metadata.json
+++ b/lib/samples/identify_raster_cell/README.metadata.json
@@ -22,9 +22,7 @@
         "RasterCell.attributes",
         "RasterLayer"
     ],
-    "offline_data": [{
-        "itemId": "b5f977c78ec74b3a8857ca86d1d9b318"
-    }],
+    "offline_data": ["b5f977c78ec74b3a8857ca86d1d9b318"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISMapViewController.identifyLayer",

--- a/lib/samples/navigate_route_with_rerouting/README.metadata.json
+++ b/lib/samples/navigate_route_with_rerouting/README.metadata.json
@@ -25,12 +25,8 @@
         "VoiceGuidance"
     ],
     "offline_data": [
-      {
-        "itemId": "df193653ed39449195af0c9725701dca"
-      },
-      {
-        "itemId": "4caec8c55ea2463982f1af7d9611b8d5"
-      }
+      "df193653ed39449195af0c9725701dca",
+      "4caec8c55ea2463982f1af7d9611b8d5"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/query_dynamic_entities/README.metadata.json
+++ b/lib/samples/query_dynamic_entities/README.metadata.json
@@ -23,9 +23,7 @@
         "DynamicEntityQueryParameters",
         "DynamicEntityQueryResult"
     ],
-    "offline_data": [{
-        "itemId": "c78e297e99ad4572a48cdcd0b54bed30"
-    }],
+    "offline_data": ["c78e297e99ad4572a48cdcd0b54bed30"],
     "redirect_from": [],
     "relevant_apis": [
         "DynamicEntity",

--- a/lib/samples/search_symbol_style_dictionary/README.metadata.json
+++ b/lib/samples/search_symbol_style_dictionary/README.metadata.json
@@ -1,9 +1,7 @@
 {
     "category": "Visualization",
     "description": "Find symbols within the mil2525d specification using one or more search criteria, such as name, tag, symbol class, category, or key.",
-    "offline_data": [{
-        "itemId": "c78b149a1d52414682c86a5feeb13d30"
-    }],
+    "offline_data": ["c78b149a1d52414682c86a5feeb13d30"],
     "ignore": false,
     "images": [
         "search_symbol_style_dictionary.png",

--- a/lib/samples/show_device_location_with_nmea_data_sources/README.metadata.json
+++ b/lib/samples/show_device_location_with_nmea_data_sources/README.metadata.json
@@ -18,9 +18,7 @@
         "NmeaLocationDataSource",
         "NmeaSatelliteInfo"
     ],
-     "offline_data": [{
-        "itemId": "d5bad9f4fee9483791e405880fb466da"
-    }],
+    "offline_data": ["d5bad9f4fee9483791e405880fb466da"],
     "redirect_from": [],
     "relevant_apis": [
         "ArcGISLocation",

--- a/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/README.metadata.json
+++ b/lib/samples/show_exploratory_viewshed_from_geoelement_in_scene/README.metadata.json
@@ -21,9 +21,7 @@
         "ModelSceneSymbol",
         "OrbitGeoElementCameraController"
     ],
-    "offline_data": [{
-        "itemId": "07d62a792ab6496d9b772a24efea45d0"
-    }],
+    "offline_data": ["07d62a792ab6496d9b772a24efea45d0"],
     "redirect_from": [],
     "relevant_apis": [
         "AnalysisOverlay",

--- a/lib/samples/show_interactive_viewshed_with_analysis_overlay/README.metadata.json
+++ b/lib/samples/show_interactive_viewshed_with_analysis_overlay/README.metadata.json
@@ -25,9 +25,7 @@
         "ViewshedParameters"
     ],
     "offline_data": [
-        {
-            "itemId": "aa97788593e34a32bcaae33947fdc271"
-        }
+        "aa97788593e34a32bcaae33947fdc271"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/show_line_of_sight_analysis_in_map/README.metadata.json
+++ b/lib/samples/show_line_of_sight_analysis_in_map/README.metadata.json
@@ -23,9 +23,7 @@
         "ObserverTargetPairs"
     ],
     "offline_data": [
-        {
-            "itemId": "aa97788593e34a32bcaae33947fdc271"
-        }
+        "aa97788593e34a32bcaae33947fdc271"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/snap_geometry_edits_with_utility_network_rules/README.metadata.json
+++ b/lib/samples/snap_geometry_edits_with_utility_network_rules/README.metadata.json
@@ -29,9 +29,7 @@
         "UtilityNetwork"
     ],
     "offline_data": [
-      {
-        "itemId": "0fd3a39660d54c12b05d5f81f207dffd"
-      }
+            "0fd3a39660d54c12b05d5f81f207dffd"
     ],
     "redirect_from": [],
     "relevant_apis": [

--- a/lib/samples/style_features_with_custom_dictionary/README.metadata.json
+++ b/lib/samples/style_features_with_custom_dictionary/README.metadata.json
@@ -2,9 +2,7 @@
     "category": "Visualization",
     "description": "Use a custom dictionary style created from a web style or local style file (.stylx) to symbolize features using a variety of attribute values.",
     "offline_data": [
-        {
-            "itemId": "751138a2e0844e06853522d54103222a"
-        }
+        "751138a2e0844e06853522d54103222a"
     ],
     "ignore": false,
     "images": [


### PR DESCRIPTION
Now that "offline_data" has only one field (the itemId), it can be simplified in the JSON to just a list of strings.

before
```json
    "offline_data": [
      {
        "itemId": "cb1b20748a9f4d128dad8a87244e3e37"
      },
      {
        "itemId": "68ec42517cdd439e81b036210483e8e7"
      },
      {
        "itemId": "15a7cbd3af1e47cfa5d2c6b93dc44fc2"
      }
    ],
```
after
```json
    "offline_data": [
      "cb1b20748a9f4d128dad8a87244e3e37",
      "68ec42517cdd439e81b036210483e8e7",
      "15a7cbd3af1e47cfa5d2c6b93dc44fc2"
    ],
```