### PR TITLE
pin file_picker to avoid dependency problems in 12.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: ^2.12.0
   build: ^4.0.7
   build_config: ^1.3.1
-  file_picker: ^12.0.0-beta.7
+  file_picker: 12.0.0-beta.7
   flutter:
     sdk: flutter
   flutter_archive: ^6.3.1


### PR DESCRIPTION
The file_picker package recently released its 12.0.0 version. It causes a dependency problem for us. Thus, we pin file_picker to 12.0.0-beta.7 for now so that we can continue to build. We'll resolve the problem later.