### PR TITLE
update to compileSdk 37

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.esri.arcgis_maps_sdk_flutter_samples"
-    compileSdk = 36
+    compileSdk = 37
     ndkVersion = "28.2.13676358"
 
     compileOptions {


### PR DESCRIPTION
Switch to compleSdk=37 for compatibility with the 11.0.0 release of flutter_secure_storage