### PR TITLE
Switch to flutter.compileSdkVersion

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.esri.arcgis_maps_sdk_flutter_samples"
-    compileSdk = 37
+    compileSdk = flutter.compileSdkVersion
     ndkVersion = "28.2.13676358"
 
     compileOptions {


### PR DESCRIPTION
Now that arcgis_maps has moved to flutter_secure_storage 11.1.0, we can use flutter.compileSdkVersion